### PR TITLE
Dev/golinks routing

### DIFF
--- a/next/lib/README.md
+++ b/next/lib/README.md
@@ -1,0 +1,1 @@
+This folder contains the application's library code.

--- a/next/lib/middlewares/golinks.ts
+++ b/next/lib/middlewares/golinks.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isUrlValid } from "../utils";
+
+
+const golinks: Record<string, string> = {
+    "google": "https://google.com/",
+    "next": "https://nextjs.org/",
+    "agile": "https://agilemanifesto.org/"
+}
+
+const getDestinationUrl = async (goLink: string) => {
+    return golinks[goLink];
+}
+
+/** Middleware to handle golinks.
+ * Checks the following:
+ *  - if the path starts with "/go/"
+ * - if the go link exists in the data store
+ * - if the destination is a valid URL
+ * - if the destination is a live site
+ * 
+ * If all checks pass, redirects to the destination.
+ * Otherwise, returns NextResponse.next() to continue the middleware chain.
+ */
+export const golinksMiddleware = async (request: NextRequest) => {
+    const { pathname } = request.nextUrl;
+    // Only run golinks middleware logic for paths starting with "/go/"
+    if (pathname.startsWith('/go/')) {
+        const goLink = pathname.split('/go/')[1];
+        const destination = await getDestinationUrl(goLink); // this would be replaced with a database lookup
+
+        // If the destination exists and is valid, redirect to it
+        if (destination && isUrlValid(destination)) {
+            // check if the url is a live site
+            const response = await fetch(destination);
+            if (response.ok) {
+                // redirect to the destination
+                return NextResponse.redirect(destination);
+            }
+        }
+    }
+
+    // Signal to continue the middleware chain (see middleware.ts)
+    return NextResponse.next();
+}

--- a/next/lib/utils.ts
+++ b/next/lib/utils.ts
@@ -1,0 +1,12 @@
+export const isUrlValid = (str: string) => {
+    const pattern = new RegExp(
+        '^(https?:\\/\\/)?' + // protocol
+        '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
+        '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR IP (v4) address
+        '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
+        '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
+        '(\\#[-a-z\\d_]*)?$', // fragment locator
+        'i'
+    );
+    return pattern.test(str);
+}

--- a/next/middleware.ts
+++ b/next/middleware.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { golinksMiddleware } from './lib/middlewares/golinks';
+
+export async function middleware(request: NextRequest) {
+    // Run the golinks middleware logic
+    let response = await golinksMiddleware(request);
+    // If the response is not NextResponse.next(), terminate the middleware chain
+    // and return the response. This would occur if the middleware redirects or rewrites.
+    if (response != NextResponse.next()) {
+        return response;
+    }
+}


### PR DESCRIPTION
Implemented go links routing behavior.

Added nextjs middleware to check go link requests, fetch the destination URL from a test data store, verifies that the link is valid and goes to a live site, and redirects to it.

If any of those checks fail, the middleware passes the request forwards (which currently goes nowhere since this is the only middleware function.

You can test the behavior by changing the url to /go/google or /go/next or /go/agile (the three test links I added).