### PR TITLE
dev/uniform-styling

### DIFF
--- a/next/app/about/AboutUsSlot.tsx
+++ b/next/app/about/AboutUsSlot.tsx
@@ -17,18 +17,18 @@ export class AboutUsSlot implements ZCardContent {
     getAlt = () => this.alt;
 
     toContent(): FC {
-        // eslint-disable-next-line react/display-name
-        return () =>
-            (
-                <div>
-                    <h3 className="text-3xl font-bold">
+        return () => {
+            return (
+                <div className='general-classes'>
+                    <h2 className='title-classes'>
                         {this.name}
-                    </h3>
-                    <p className="mt-8 sm:text-xl/relaxed">
+                    </h2>
+                    <p className='description-classes'>
                         {this.description}
                     </p>
                 </div>
             );
+        }
     }
 
     getImageSrc(): string {

--- a/next/app/about/AboutUsSlot.tsx
+++ b/next/app/about/AboutUsSlot.tsx
@@ -23,6 +23,7 @@ export class AboutUsSlot implements ZCardContent {
                     <h2 className='title-classes'>
                         {this.name}
                     </h2>
+                    
                     <p className='description-classes'>
                         {this.description}
                     </p>

--- a/next/app/about/committees/CommitteeSlot.tsx
+++ b/next/app/about/committees/CommitteeSlot.tsx
@@ -22,17 +22,13 @@ export class CommitteeSlot implements ZCardContent {
 
     toContent(): FC<{}> {
         return () => {
-            const generalClasses = 'text-left pt-4 pb-32 md:py-16'
-            const nameClasses = 'bg-clip-text font-bold text-3xl/[3rem]'
-            const descriptionClasses = 'mt-4 pb-4 text-xl/relaxed'
-        
             return (
-            <div className={generalClasses}>
-                <h2 className={nameClasses}>
+            <div className="general-classes">
+                <h2 className='name-classes'>
                     {this.name}
                 </h2>
         
-                <p className={descriptionClasses}>
+                <p className='description-classes'>
                     {this.description}
                 </p>
             </div>

--- a/next/app/about/committees/CommitteeSlot.tsx
+++ b/next/app/about/committees/CommitteeSlot.tsx
@@ -23,15 +23,15 @@ export class CommitteeSlot implements ZCardContent {
     toContent(): FC<{}> {
         return () => {
             return (
-            <div className="general-classes">
-                <h2 className='name-classes'>
-                    {this.name}
-                </h2>
-        
-                <p className='description-classes'>
-                    {this.description}
-                </p>
-            </div>
+                <div className="general-classes">
+                    <h2 className='name-classes'>
+                        {this.name}
+                    </h2>
+                
+                    <p className='description-classes'>
+                        {this.description}
+                    </p>
+                </div>
             );
         }
     }

--- a/next/app/about/committees/page.tsx
+++ b/next/app/about/committees/page.tsx
@@ -6,26 +6,16 @@ export default function Committees() {
   return (
     <>
       <section>
-        <div className="flex flex-col items-center max-w-screen-xl">            
-            <div className="mx-auto px-4 sm: py-16 md:pb-8 max-w-2xl">
-                <div className="text-center flex flex-col items-center w-full">
-                    <h1
-                    className="bg-gradient-to-t from-primary to-secondary bg-clip-text
-                                text-4xl/[3rem] font-extrabold text-transparent md:text-5xl/[4rem]"
-                    >
-                    Committees
-                    </h1>
-
-                    <p className="mx-auto mt-4 text-xl/relaxed">
-                    The Society of Software Engineers delegates responsibility for tasks with committees. These
-                    committees play pivotal roles in organizing events, facilitating projects, providing platforms for
-                    knowledge exchange, and more. Together we create opportunities for members to connect,
-                    collaborate, and learn from one another.
-
-                    </p>
-                </div>
+        <div className="text-page-structure">
+            <h1>Committees</h1>
+            <div className="subtitle-structure">
+              <p>
+                The Society of Software Engineers delegates responsibility for tasks with committees. These
+                committees play pivotal roles in organizing events, facilitating projects, providing platforms for
+                knowledge exchange, and more. Together we create opportunities for members to connect,
+                collaborate, and learn from one another.
+              </p>
             </div>
-
             <ZCardContainer contentSlots={
               CommitteeSlotData.map(
                 data => new CommitteeSlot(

--- a/next/app/about/committees/page.tsx
+++ b/next/app/about/committees/page.tsx
@@ -16,6 +16,7 @@ export default function Committees() {
                 collaborate, and learn from one another.
               </p>
             </div>
+            
             <ZCardContainer contentSlots={
               CommitteeSlotData.map(
                 data => new CommitteeSlot(

--- a/next/app/about/get-involved/InvolvementSlot.tsx
+++ b/next/app/about/get-involved/InvolvementSlot.tsx
@@ -23,15 +23,15 @@ export class InvolvementSlot implements ZCardContent {
     toContent(): FC<{}> {
         return () => {       
             return (
-            <div className='general-classes'>
-                <h2 className='title-classes'>
-                    {this.title}
-                </h2>
-        
-                <p className='description-classes'>
-                    {this.body}
-                </p>
-            </div>
+                <div className='general-classes'>
+                    <h2 className='title-classes'>
+                        {this.title}
+                    </h2>
+                
+                    <p className='description-classes'>
+                        {this.body}
+                    </p>
+                </div>
             );
         }
     }

--- a/next/app/about/get-involved/InvolvementSlot.tsx
+++ b/next/app/about/get-involved/InvolvementSlot.tsx
@@ -21,18 +21,14 @@ export class InvolvementSlot implements ZCardContent {
     }
 
     toContent(): FC<{}> {
-        return () => {
-            const generalClasses = 'text-left pt-4 pb-32 md:py-16'
-            const titleClasses = 'bg-clip-text font-bold text-3xl/[3rem]'
-            const bodyClasses = 'mt-4 pb-4 text-xl/relaxed'
-        
+        return () => {       
             return (
-            <div className={generalClasses}>
-                <h2 className={titleClasses}>
+            <div className='general-classes'>
+                <h2 className='title-classes'>
                     {this.title}
                 </h2>
         
-                <p className={bodyClasses}>
+                <p className='description-classes'>
                     {this.body}
                 </p>
             </div>

--- a/next/app/about/get-involved/page.tsx
+++ b/next/app/about/get-involved/page.tsx
@@ -23,38 +23,37 @@ export default function GetInvolved() {
     return (
         <>
             <section>
-                <div className="mx-auto max-w-screen-xl px-4 py-16 lg:flex">
-                    <div className="text-center flex flex-col items-center w-full px-8 lg:max-w-6xl">
-                        <h1 className="bg-gradient-to-t from-primary to-secondary bg-clip-text
-                                text-4xl/[3rem] font-extrabold text-transparent md:text-5xl/[4rem]">
-                            Get Involved!
-                        </h1>
-                        {/* insert zcard here */}
-                        <ZCardContainer contentSlots={
-                            InvolvementSlotData.map(
-                                data => new InvolvementSlot(
-                                    data.imageSrc, data.title, data.body
-                                )
-                            )
-                        } />
-
-                        {/* Buttons to press on */}
-                        <section className="pt-6">
-                            <div className="text-left space-x-5 mt-3 flex">
-                                <h2 className="bg-gradient-to-t from-primary to-secondary bg-clip-text
-                         text-3xl/[3rem] font-extrabold text-transparent sm:text-3xl/[3rem]">COME TO OUR EVENTS!</h2>
-                                <CTAButton href="http://localhost:3000/events" text="Events" />
-                            </div>
-                        </section>
-                        <section className="pt-6">
-                            <div className="text-left space-x-5 mt-3 flex">
-                                <h2 className="bg-gradient-to-t from-primary to-secondary bg-clip-text
-                         text-3xl/[3rem] font-extrabold text-transparent sm:text-3xl/[3rem]">TALK TO US!</h2>
-                                <CTAButton href="https://rit-sse.slack.com/" text="Join our Slack" />
-                            </div>
-                        </section>
+                <div className="text-page-structure">
+                    <h1>Get Involved!</h1>
+                    <div className='subtitle-structure'>
+                        <p>
+                            fart and poop.md
+                        </p>
                     </div>
-                </div>
+
+                    <ZCardContainer contentSlots={
+                        InvolvementSlotData.map(
+                            data => new InvolvementSlot(
+                                data.imageSrc, data.title, data.body
+                            )
+                        )
+                    }/>
+
+                    <section className="pt-6">
+                        <div className="text-left space-x-5 mt-3 flex">
+                            <h2 className="bg-gradient-to-t from-primary to-secondary bg-clip-text
+                        text-3xl/[3rem] font-extrabold text-transparent sm:text-3xl/[3rem]">COME TO OUR EVENTS!</h2>
+                            <CTAButton href="http://localhost:3000/events" text="Events" />
+                        </div>
+                    </section>
+                    <section className="pt-6">
+                        <div className="text-left space-x-5 mt-3 flex">
+                            <h2 className="bg-gradient-to-t from-primary to-secondary bg-clip-text
+                        text-3xl/[3rem] font-extrabold text-transparent sm:text-3xl/[3rem]">TALK TO US!</h2>
+                            <CTAButton href="https://rit-sse.slack.com/" text="Join our Slack" />
+                        </div>
+                    </section>
+                    </div>
             </section>
         </>
 

--- a/next/app/about/get-involved/page.tsx
+++ b/next/app/about/get-involved/page.tsx
@@ -27,7 +27,7 @@ export default function GetInvolved() {
                     <h1>Get Involved!</h1>
                     <div className='subtitle-structure'>
                         <p>
-                            fart and poop.md
+                            Are you ready to make an impact? Dive in the heart of the SSE and become part of a vibrant community dedicated to innnovation and collaboration. Whether you are passionate about coding, organizing events, or fostering connections, there is a place for you here. Join us in shaping the future of the SSE as we work together to create meaningful opportunities for growth, learning, and impact. Let's build something incredible together.
                         </p>
                     </div>
 

--- a/next/app/about/page.tsx
+++ b/next/app/about/page.tsx
@@ -13,29 +13,25 @@ export const metadata: Metadata = {
 const About = () => {
   return (
     <>
-      <div className="px-4 py-16 flex flex-1 flex-col items-center w-11/12">
-        <h1
-          className="bg-gradient-to-t from-primary to-secondary bg-clip-text
-          text-4xl/[3rem] font-extrabold text-transparent md:text-5xl/[4rem]"
-        >
-          About Us
-        </h1>
+      <section>
+        <div className="text-page-structure">
+          <h1>About Us</h1>
+          <div className="subtitle-structure">
+            <p>
+              The Society of Software Engineers at RIT fosters a vibrant community
+              of tech enthusiasts, bridging academia with industry partnerships
+              from giants like Microsoft to Apple, ensuring our members thrive in
+              their future careers.
+            </p>
+          </div>
 
-        <div className="w-full md:w-5/6 space-y-24 pb-8">
-          <p className="w-3/5 mt-4 text-center sm:text-xl/relaxed m-auto">
-            The Society of Software Engineers at RIT fosters a vibrant community
-            of tech enthusiasts, bridging academia with industry partnerships
-            from giants like Microsoft to Apple, ensuring our members thrive in
-            their future careers.
-          </p>
+          <ZCardContainer contentSlots={
+            slotData.map(slot => new AboutUsSlot(
+                slot.imageSrc, slot.name, slot.description, slot.alt
+            ))
+          } />
         </div>
-
-        <ZCardContainer contentSlots={
-          slotData.map(slot => new AboutUsSlot(
-              slot.imageSrc, slot.name, slot.description, slot.alt
-          ))
-        } />
-      </div>
+      </section>
     </>
   );
 };

--- a/next/app/globals.scss
+++ b/next/app/globals.scss
@@ -129,6 +129,35 @@
     @apply bg-base-200;
   }
 
+  .z-card-container {
+    padding-top: 1rem;
+  
+    > div {
+      margin-bottom: 2rem;
+    }
+  }
+  
+  
+  .z-card {
+    display: flex;
+    flex-direction: column; 
+    margin: 1rem 0; 
+    padding: 20px;
+    border-radius: 8px;
+  
+    @media (min-width: 768px) { 
+      flex-direction: row; 
+    }
+  
+    .w-full {
+      border-radius: 8px;
+    }
+  
+    .gap-24 {
+      gap: 24px;
+    }
+  }
+
 }
 
 ::selection {

--- a/next/app/globals.scss
+++ b/next/app/globals.scss
@@ -3,6 +3,59 @@
 @tailwind utilities;
 
 @layer base {
+  .text-page-structure {
+    @apply mx-auto;
+    @apply max-w-screen-xl;
+    @apply px-4;
+    @apply py-16;
+    @apply lg:flex;
+    @apply flex;
+    @apply flex-1;
+    @apply flex-col;
+    @apply items-center;
+    @apply w-11/12;
+  }
+  .text-page-structure > h1 {
+    @apply bg-gradient-to-br;
+    @apply from-primary;
+    @apply to-primary;
+    @apply bg-clip-text;
+    @apply text-4xl/[3rem];
+    @apply font-extrabold;
+    @apply text-transparent;
+    @apply sm:text-5xl/[4rem];
+    @apply text-center;
+  }
+
+  .subtitle-structure {
+    @apply w-full;
+    @apply md:w-5/6;
+    @apply space-y-24; 
+    @apply pb-8;
+  }
+
+  .subtitle-structure p {
+    @apply text-center; 
+    @apply mx-auto; 
+    @apply mt-4; 
+    @apply text-xl/relaxed;
+  }
+  /* .text-page-structure > div {
+    @apply w-full;
+    @apply md:w-5/6;
+    @apply space-y-24; 
+    @apply pb-8;
+  }
+  .text-page-structure > div > p {
+    @apply w-3/5; 
+    @apply mt-4;
+    @apply text-center; 
+    @apply sm:text-xl/relaxed; 
+    @apply m-auto;
+  } */
+
+
+  
   h1 {
     @apply bg-gradient-to-br;
     @apply from-primary;

--- a/next/app/globals.scss
+++ b/next/app/globals.scss
@@ -40,6 +40,25 @@
     @apply mt-4; 
     @apply text-xl/relaxed;
   }
+
+  .general-classes{
+    @apply text-left;
+    @apply pt-4;
+    @apply pb-32;
+    @apply md:py-16;
+  }
+
+  .name-classes{
+    @apply bg-clip-text;
+    @apply font-bold;
+    @apply text-3xl/[3rem];
+  }
+
+  .description-classes{
+    @apply mt-4;
+    @apply pb-4;
+    @apply text-xl/relaxed;
+  }
   /* .text-page-structure > div {
     @apply w-full;
     @apply md:w-5/6;

--- a/next/components/nav/Navbar.tsx
+++ b/next/components/nav/Navbar.tsx
@@ -80,7 +80,7 @@ const Navbar: React.FC = () => {
     return (
         <nav
             id="navbar"
-            className="sticky top-0 z-50 flex items-center justify-center bg-base-100 bg-opacity-0 filter backdrop-blur-sm"
+            className="top-0 z-50 flex items-center justify-center bg-opacity-100 filter"
         >
             <div
                 id="nav-content"


### PR DESCRIPTION
Created styles in global.scss for pages that use ZCardContainers. Christian and I created a uniform style for pages like 'About Us,' 'Committees,' and 'Get Involved,' which all use ZCardContainers. We also created a description for the Get Involved page.

<img width="1111" alt="Screenshot 2024-02-18 at 3 19 10 PM" src="https://github.com/rit-sse/WebsiteTheSSEquel/assets/143859287/c4d824a1-8a20-4143-bd36-cb29866e1813">

<img width="961" alt="Screenshot 2024-02-18 at 3 19 36 PM" src="https://github.com/rit-sse/WebsiteTheSSEquel/assets/143859287/142cd738-f6f9-4ba2-93f9-0bca85dc977c">

<img width="715" alt="Screenshot 2024-02-18 at 3 22 40 PM" src="https://github.com/rit-sse/WebsiteTheSSEquel/assets/143859287/6656352b-5ad7-45c1-9532-e8b1459d03e3">
