### PR TITLE
GoLinks Bugfix: Frontend incorrectly displayed golinks after one was edited/deleted/added

### DIFF
--- a/next/app/go/GoLinksContainer.tsx
+++ b/next/app/go/GoLinksContainer.tsx
@@ -13,13 +13,13 @@ const GoLinksContainer: React.FC<GoLinksContainerProps> = ({
   const pinnedGoLinks = goLinkData
     .filter((data) => data.pinned === true)
     .map((data, index) => (
-      <GoLink key={`pinned-${index}`} {...data} fetchData={fetchData} />
+      <GoLink key={`pinned-${data.id}`} {...data} fetchData={fetchData} />
     ));
 
   const unpinnedGoLinks = goLinkData
     .filter((data) => !data.pinned)
     .map((data, index) => (
-      <GoLink key={`unpinned-${index}`} {...data} fetchData={fetchData} />
+      <GoLink key={`unpinned-${data.id}`} {...data} fetchData={fetchData} />
     ));
 
   const [goLinkList, setGoLinkList] = useState<React.JSX.Element[]>([]);


### PR DESCRIPTION
Changed GoLink keys from index to data.id in GoLinksContainer.tsx, lines 16 & 22. Bug seems to be fixed now