### PR TITLE
Fixes the goLinks

### DIFF
--- a/next/lib/middlewares/golinks.ts
+++ b/next/lib/middlewares/golinks.ts
@@ -27,20 +27,15 @@ const getDestinationUrl = async (goUrl: string) => {
  * Otherwise, returns NextResponse.next() to continue the middleware chain.
  */
 export const golinksMiddleware = async (request: NextRequest) => {
-    const { pathname } = request.nextUrl;
-    // Only run golinks middleware logic for paths starting with "/go/"
-    if (pathname.startsWith('/go/')) {
-        const goLink = pathname.split('/go/')[1];
-        const destination = await getDestinationUrl(goLink); // this would be replaced with a database lookup
-
+  const { pathname } = request.nextUrl;
+  // Only run golinks middleware logic for paths starting with "/go/"
+  if (pathname.startsWith('/go/')) {
+    const goLink = pathname.split('/go/')[1];
+    const destination = await getDestinationUrl(goLink); // this would be replaced with a database lookup
     // If the destination exists and is valid, redirect to it
     if (destination && isUrlValid(destination)) {
       // check if the url is a live site
-      const response = await fetch(destination);
-      if (response.ok) {
-        // redirect to the destination
-        return NextResponse.redirect(destination);
-      }
+      return NextResponse.redirect(destination);
     }
   }
 


### PR DESCRIPTION
Previously, the middleware would check to see if the specified goLinks URL was alive. If the URL was from a different origin, policies would be in place to block the request, which made the middleware think that it was not valid and therefore sending the user to a 404 page.
This PR removes that validation check and sends the user regardless.