### PR TITLE
Fix: Projects with Empty Fields

### DIFF
--- a/next/app/projects/AddProjectModal.tsx
+++ b/next/app/projects/AddProjectModal.tsx
@@ -58,8 +58,6 @@ const AddProjectModal = ({
             invalidFields.push("description");
         if(progress.trim() == "")
             invalidFields.push("progress");
-        if(repoLink.trim() == "")
-            invalidFields.push("repoLink")  
 
         // If invalidFields captured any cases, then we know something went wrong, alert the user, and join the missing fields into a string.
         if(invalidFields.length > 0) {
@@ -138,7 +136,7 @@ const AddProjectModal = ({
                                 <ProjectModalInput label="Description *" setTextState={setDescription} isRichText={true} presetValue={description}/>
                                 <ProjectModalDropdown text={"Select Lead"} setState={setUser} options={users} />
                                 <ProjectModalInput label="Progress *" setTextState={setProgress}  presetValue={progress}/>
-                                <ProjectModalInput label="Repository Link *" setTextState={setRepoLink}  presetValue={repoLink}/>
+                                <ProjectModalInput label="Repository Link" setTextState={setRepoLink}  presetValue={repoLink}/>
                                 <ProjectModalInput label="Content URL" setTextState={setContentURL}  presetValue={contentURL}/>
                                 <ProjectModalInput label="Project Image URL" setTextState={setProjectImage}  presetValue={projectImage}/>
                                 <ProjectModalCheckbox label="Completed" checked={completed} setChecked={setCompleted}/>

--- a/next/app/projects/ProjectModal.tsx
+++ b/next/app/projects/ProjectModal.tsx
@@ -250,19 +250,36 @@ const ProjectModal = ({enabled, setEnabled, project, isOfficer}: ProjectModalInt
                                             :
                                             <ProjectLink url={"mailto:" + lead.email} text="Email"/>
                                         }
+
+                                        {/* Below will look at little stinky with the wrapped stuff */}
+                                        {/* It checks if edit mode is on, and if it isnt, it checks the value to make sure its nonempty */}
                                         {/* Repo Link */}
                                         {
                                             editMode ?
                                             <ProjectModalInput label="Repository Link" setTextState={setRepoLink} presetValue={repoLink} />
                                             :
-                                            <ProjectLink url={project.repoLink} text="Repo Link" />
+                                            <>
+                                                {
+                                                project.repoLink != "" ?    
+                                                <ProjectLink url={project.repoLink} text="Repo Link" />
+                                                :
+                                                undefined
+                                                }
+                                            </>
                                         }
                                         {/* Content Link */}
                                         {
                                             editMode ?
                                             <ProjectModalInput label="Content Link" setTextState={setContentURL} presetValue={contentURLLink} />
                                             :
-                                            <ProjectLink url={project.contentURL} text="Content URL Link" />
+                                            <>
+                                            {
+                                                project.contentURL != "" ?
+                                                <ProjectLink url={project.contentURL} text="Content URL Link" />
+                                                :
+                                                undefined
+                                            }
+                                            </>
                                         }
                                         {/* Project Image URL */}
                                         {


### PR DESCRIPTION
This PR lets projects with empty fields have their associated link buttons not visible.
Also makes the repository URL optional, for whatever reason the Project Head might desire.