### PR TITLE
Fix prisma migrations not being tracked

### DIFF
--- a/next/.gitignore
+++ b/next/.gitignore
@@ -13,8 +13,6 @@
 /.next/
 /out/
 
-# prisma
-/next/prisma/migrations
 
 # production
 /build
@@ -33,8 +31,6 @@ yarn-error.log*
 .env*.local
 .env
 
-#Prisma migration
-prisma/migrations
 
 # vercel
 .vercel

--- a/next/prisma/migrations/20251008222713_add_membership_table/migration.sql
+++ b/next/prisma/migrations/20251008222713_add_membership_table/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "Memberships" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "reason" TEXT NOT NULL,
+    "date_given" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Memberships_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Memberships" ADD CONSTRAINT "Memberships_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/next/prisma/migrations/20251008223238_rename_date_given/migration.sql
+++ b/next/prisma/migrations/20251008223238_rename_date_given/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `date_given` on the `Memberships` table. All the data in the column will be lost.
+  - Added the required column `dateGiven` to the `Memberships` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Memberships" DROP COLUMN "date_given",
+ADD COLUMN     "dateGiven" TIMESTAMP(3) NOT NULL;

--- a/next/prisma/migrations/20260123021553_ui_over_haul/migration.sql
+++ b/next/prisma/migrations/20260123021553_ui_over_haul/migration.sql
@@ -1,0 +1,119 @@
+-- AlterTable
+ALTER TABLE "Account" ADD COLUMN     "refresh_token_expires_in" INTEGER;
+
+-- CreateTable
+CREATE TABLE "Alumni" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "linkedIn" TEXT,
+    "gitHub" TEXT,
+    "description" TEXT,
+    "image" TEXT NOT NULL DEFAULT 'https://source.boringavatars.com/beam/',
+    "start_date" TEXT NOT NULL,
+    "end_date" TEXT NOT NULL,
+    "quote" TEXT NOT NULL DEFAULT '',
+    "previous_roles" TEXT NOT NULL DEFAULT '',
+
+    CONSTRAINT "Alumni_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AlumniRequest" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "linkedIn" TEXT,
+    "gitHub" TEXT,
+    "description" TEXT,
+    "image" TEXT NOT NULL DEFAULT 'https://source.boringavatars.com/beam/',
+    "start_date" TEXT NOT NULL,
+    "end_date" TEXT NOT NULL,
+    "quote" TEXT NOT NULL DEFAULT '',
+    "previous_roles" TEXT NOT NULL DEFAULT '',
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AlumniRequest_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "HandoverDocument" (
+    "id" SERIAL NOT NULL,
+    "positionId" INTEGER NOT NULL,
+    "content" TEXT NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "HandoverDocument_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Sponsor" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "logoUrl" TEXT NOT NULL,
+    "websiteUrl" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Sponsor_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PurchaseRequest" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "name" TEXT NOT NULL,
+    "committee" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "estimatedCost" DECIMAL(10,2) NOT NULL,
+    "actualCost" DECIMAL(10,2),
+    "plannedDate" TIMESTAMP(3) NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "notifyEmail" TEXT NOT NULL,
+    "receiptImage" TEXT,
+    "receiptEmail" TEXT,
+    "eventName" TEXT,
+    "eventDate" TIMESTAMP(3),
+    "attendanceData" TEXT,
+    "attendanceImage" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PurchaseRequest_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Invitation" (
+    "id" SERIAL NOT NULL,
+    "invitedEmail" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "positionId" INTEGER,
+    "startDate" TIMESTAMP(3),
+    "endDate" TIMESTAMP(3),
+    "invitedBy" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Invitation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "HandoverDocument_positionId_key" ON "HandoverDocument"("positionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Invitation_invitedEmail_type_key" ON "Invitation"("invitedEmail", "type");
+
+-- AddForeignKey
+ALTER TABLE "HandoverDocument" ADD CONSTRAINT "HandoverDocument_positionId_fkey" FOREIGN KEY ("positionId") REFERENCES "OfficerPosition"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PurchaseRequest" ADD CONSTRAINT "PurchaseRequest_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Invitation" ADD CONSTRAINT "Invitation_positionId_fkey" FOREIGN KEY ("positionId") REFERENCES "OfficerPosition"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Invitation" ADD CONSTRAINT "Invitation_invitedBy_fkey" FOREIGN KEY ("invitedBy") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;


### PR DESCRIPTION
This PR makes a quick fix to track migrations again, in order to help deploy DB changes quickly like expected.