### PR TITLE
fix: LinkedIn profile card links go to correct URL

### DIFF
--- a/next/app/(main)/about/credits/MemberCard.tsx
+++ b/next/app/(main)/about/credits/MemberCard.tsx
@@ -1,5 +1,5 @@
 import { CommitteeMemberProp } from "./member";
-import { ensureGithubUrl } from "@/lib/utils";
+import { ensureGithubUrl, ensureLinkedinUrl } from "@/lib/utils";
 import { Linkedin, Github, Mail } from "lucide-react";
 import { Card } from "@/components/ui/card";
 import Image from "next/image";
@@ -57,7 +57,7 @@ export default async function MemberCard({ member }: CommitteeMemberProp) {
       <div className="flex gap-3 pt-2 border-t border-border w-full justify-center mt-auto">
         {member.linkedIn && (
           <a
-            href={ensureGithubUrl(member.linkedIn)}
+            href={ensureLinkedinUrl(member.linkedIn)}
             target="_blank"
             rel="noopener noreferrer"
             className="text-muted-foreground hover:text-primary transition-colors"


### PR DESCRIPTION
Fixes #356

## Problem
LinkedIn profile card links on the credits page were incorrectly linking to `github.com/username` instead of `linkedin.com/in/username`.

## Root Cause
The `MemberCard.tsx` component was using `ensureGithubUrl()` for the LinkedIn profile links instead of `ensureLinkedinUrl()`.

## Fix
- Import `ensureLinkedinUrl` from `@/lib/utils`
- Use `ensureLinkedinUrl(member.linkedIn)` for the LinkedIn href

## Testing
Verified that the LinkedIn links now correctly link to `linkedin.com/in/...` instead of `github.com/...`