### PR TITLE
fix: resolve open issues #431, #441, #442, #443

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "development"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -21,6 +22,7 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/next"
+    target-branch: "development"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/next/__tests__/invitations.pending.route.test.ts
+++ b/next/__tests__/invitations.pending.route.test.ts
@@ -60,12 +60,16 @@ describe("/api/invitations/pending route", () => {
     ]);
     expect(mockInvitationFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({ invitedEmail: "member@g.rit.edu" }),
+        where: expect.objectContaining({
+          invitedEmail: { equals: "member@g.rit.edu", mode: "insensitive" },
+        }),
       })
     );
     expect(mockInvitationDeleteMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({ invitedEmail: "member@g.rit.edu" }),
+        where: expect.objectContaining({
+          invitedEmail: { equals: "member@g.rit.edu", mode: "insensitive" },
+        }),
       })
     );
   });

--- a/next/app/(main)/accept-invitation/page.tsx
+++ b/next/app/(main)/accept-invitation/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { signIn, useSession } from "next-auth/react";
 import {
   Card,
@@ -39,6 +39,8 @@ interface Invitation {
 export default function AcceptInvitationPage() {
   const { data: session, status } = useSession();
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const emailHint = searchParams.get("email");
   const [invitations, setInvitations] = useState<Invitation[]>([]);
   const [loading, setLoading] = useState(true);
   const [processing, setProcessing] = useState<number | null>(null);
@@ -48,7 +50,14 @@ export default function AcceptInvitationPage() {
 
     if (status === "unauthenticated") {
       // Redirect to sign in, then back here
-      signIn("google", { callbackUrl: "/accept-invitation" });
+      const callbackUrl = emailHint
+        ? `/accept-invitation?email=${encodeURIComponent(emailHint)}`
+        : "/accept-invitation";
+      signIn(
+        "google",
+        { callbackUrl },
+        emailHint ? { login_hint: emailHint } : {}
+      );
       return;
     }
 
@@ -63,7 +72,14 @@ export default function AcceptInvitationPage() {
         const data = await response.json();
         setInvitations(data);
       } else if (response.status === 401) {
-        signIn("google", { callbackUrl: "/accept-invitation" });
+        const callbackUrl = emailHint
+          ? `/accept-invitation?email=${encodeURIComponent(emailHint)}`
+          : "/accept-invitation";
+        signIn(
+          "google",
+          { callbackUrl },
+          emailHint ? { login_hint: emailHint } : {}
+        );
       }
     } catch (error) {
       console.error("Error fetching invitations:", error);
@@ -153,6 +169,20 @@ export default function AcceptInvitationPage() {
             <CardTitle>No Pending Invitations</CardTitle>
             <CardDescription>
               You don&apos;t have any pending invitations at this time.
+              {session?.user?.email && (
+                <span className="block mt-2 text-xs">
+                  Signed in as: {session.user.email}
+                </span>
+              )}
+              {emailHint &&
+                session?.user?.email &&
+                emailHint.toLowerCase() !==
+                  session.user.email.toLowerCase() && (
+                  <span className="block mt-2 text-xs text-destructive">
+                    The invitation was sent to {emailHint}. Try signing in with
+                    that account.
+                  </span>
+                )}
             </CardDescription>
           </CardHeader>
           <CardFooter className="justify-center">

--- a/next/app/(main)/dashboard/PositionsSection.tsx
+++ b/next/app/(main)/dashboard/PositionsSection.tsx
@@ -309,7 +309,6 @@ export default function PositionsSection({
     {
       key: "handover",
       header: "Handover",
-      mobileHidden: true,
       className: "hidden lg:table-cell w-[100px]",
       render: (position) => (
         <Button
@@ -335,21 +334,6 @@ export default function PositionsSection({
               <div
                 className={`flex items-center ${isMobile ? "flex-wrap gap-2" : "gap-1"}`}
               >
-                {isMobile && (
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() =>
-                      router.push(
-                        `/dashboard/positions/${position.id}/handover`
-                      )
-                    }
-                    className="gap-1.5"
-                  >
-                    <FileText className="h-3.5 w-3.5" />
-                    Handover
-                  </Button>
-                )}
                 <Button
                   size={isMobile ? "sm" : "xs"}
                   variant={isMobile ? "outline" : "ghost"}

--- a/next/app/(main)/events/calendar/AddEventForm.tsx
+++ b/next/app/(main)/events/calendar/AddEventForm.tsx
@@ -253,6 +253,14 @@ export default function AddEventForm({
               // Don't fail the whole operation if purchase request fails
             }
           }
+        } else {
+          const errorData = await prismaResponse.json().catch(() => null);
+          setError(
+            errorData?.error ||
+              "Failed to save event to database. The Google Calendar event was created but the event won't appear on the attendance page."
+          );
+          setLoading(false);
+          return;
         }
       }
 

--- a/next/app/api/invitations/pending/route.ts
+++ b/next/app/api/invitations/pending/route.ts
@@ -38,7 +38,7 @@ export async function GET(request: NextRequest) {
   // Fetch all pending invitations for this user's email
   const invitations = await prisma.invitation.findMany({
     where: {
-      invitedEmail: loggedInUser.email,
+      invitedEmail: { equals: loggedInUser.email, mode: "insensitive" },
       expiresAt: {
         gte: new Date(), // Only non-expired invitations
       },
@@ -68,7 +68,7 @@ export async function GET(request: NextRequest) {
   // Delete any expired invitations we might find
   await prisma.invitation.deleteMany({
     where: {
-      invitedEmail: loggedInUser.email,
+      invitedEmail: { equals: loggedInUser.email, mode: "insensitive" },
       expiresAt: {
         lt: new Date(),
       },

--- a/next/app/api/invitations/route.ts
+++ b/next/app/api/invitations/route.ts
@@ -256,7 +256,7 @@ export async function POST(request: NextRequest) {
   // Send invitation email
   if (isEmailConfigured()) {
     const baseUrl = getPublicBaseUrl(request);
-    const acceptUrl = `${baseUrl}/accept-invitation`;
+    const acceptUrl = `${baseUrl}/accept-invitation?email=${encodeURIComponent(email)}`;
 
     try {
       if (type === "officer" && invitation.position) {

--- a/next/lib/middlewares/authentication.ts
+++ b/next/lib/middlewares/authentication.ts
@@ -271,7 +271,7 @@ const ROUTES: { [key: string]: AuthVerifier } = {
   event: eventVerifier,
   go: allowAllVerifier,
   golinks: goLinkVerifier,
-  handover: nonGetPrimaryOfficerVerifier,
+  handover: nonGetOfficerVerifier,
   "headcount-import": primaryOfficerVerifier,
   "headcount-trends": officerVerifier,
   hourBlocks: nonGetOfficerVerifier,

--- a/next/lib/middlewares/authentication.ts
+++ b/next/lib/middlewares/authentication.ts
@@ -231,6 +231,23 @@ const libraryVerifier: AuthVerifier = async (request: NextRequest) => {
 };
 
 /**
+ * Auth verifier for invitation routes:
+ * - pending/accept/decline are accessible to any signed-in user
+ * - all other invitation routes (create, list, delete) require officer
+ */
+const invitationsVerifier: AuthVerifier = async (request: NextRequest) => {
+  const pathname = request.nextUrl.pathname;
+  if (
+    pathname === "/api/invitations/pending" ||
+    pathname === "/api/invitations/accept" ||
+    pathname === "/api/invitations/decline"
+  ) {
+    return signedInVerifier(request);
+  }
+  return officerVerifier(request);
+};
+
+/**
  * Map from API route name to authorization verifier. The verifier should be run against any request that
  * goes through that route.
  * Keys are the second element in the path segment; for example, the path "/api/golinks/officer" would
@@ -258,7 +275,7 @@ const ROUTES: { [key: string]: AuthVerifier } = {
   "headcount-import": primaryOfficerVerifier,
   "headcount-trends": officerVerifier,
   hourBlocks: nonGetOfficerVerifier,
-  invitations: officerVerifier,
+  invitations: invitationsVerifier,
   library: libraryVerifier,
   memberships: nonGetOfficerVerifier,
   "mentee-headcount": officerVerifier,

--- a/next/lib/schemas/event.ts
+++ b/next/lib/schemas/event.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const CreateEventSchema = z.object({
   id: z.string().min(1).max(100),
   title: z.string().min(1).max(200),
-  description: z.string().min(1).max(2000),
+  description: z.string().max(2000),
   date: z.string().min(1),
   location: z.string().max(200).optional(),
   image: z.string().max(500).optional(),
@@ -14,7 +14,7 @@ export const CreateEventSchema = z.object({
 export const UpdateEventSchema = z.object({
   id: z.string().min(1).max(100),
   title: z.string().min(1).max(200).optional(),
-  description: z.string().min(1).max(2000).optional(),
+  description: z.string().max(2000).optional(),
   date: z.string().min(1).optional(),
   location: z.string().max(200).optional(),
   image: z.string().max(500).optional(),


### PR DESCRIPTION
## Summary

Fixes all 4 open issues. Issues #443 and #431 share the same root cause: commit 013ccf7 ("enforce RBAC across middleware") over-tightened permissions on the `invitations` and `handover` routes.

### #441 — Dependabot PRs target `main` instead of `development`
- Added `target-branch: "development"` to both npm ecosystem blocks in `.github/dependabot.yml`

### #442 — GCal page creates Google Calendar event but no database record
- Removed `.min(1)` from the event description Zod schema (the form textarea is optional, so empty descriptions are valid)
- Added error handling in `AddEventForm.tsx` so failed database saves surface an error instead of silently closing the modal

### #443 — Mentors unable to accept invitation from email link
- **Root cause:** Middleware set `invitations: officerVerifier`, blocking all `/api/invitations/*` routes for non-officers. Confirmed via prod DB and server logs on eggs — Ben Bowen's invitation exists and matches, but the pending endpoint returned 403.
- Added custom `invitationsVerifier` that allows signed-in users to access `pending/accept/decline` while keeping officer-only on management routes
- Added `login_hint` to Google OAuth so the correct account is pre-selected
- Made email matching case-insensitive in the pending invitations query
- Added diagnostic info on the "no invitations" screen showing which account is signed in

### #431 — Division Managers can't edit handover documents
- **Root cause:** Middleware set `handover: nonGetPrimaryOfficerVerifier`, blocking PUT for non-primary officers. Changed to `nonGetOfficerVerifier` so any officer can edit.
- Made handover button visible on mobile for all officers (removed `mobileHidden` and duplicate button in actions column)

## Test plan
- [x] All 384 tests pass (89 test files)
- [x] Updated pending invitations test for case-insensitive email match
- [ ] Verify non-officer can access `/api/invitations/pending` (no longer 403)
- [ ] Verify division manager can PUT to `/api/handover/[id]` (no longer 403)
- [ ] Verify event creation with empty description succeeds
- [ ] Verify Dependabot PRs target `development` on next scheduled run

Closes #431, closes #441, closes #442, closes #443