### PR TITLE
Fix CSP blocking Google OAuth and images on prod

### DIFF
--- a/next/__tests__/securityHeaders.test.ts
+++ b/next/__tests__/securityHeaders.test.ts
@@ -76,6 +76,8 @@ describe("security headers", () => {
     expect(policy).toContain("https://api.github.com");
     expect(policy).toContain("https://calendar.google.com");
     expect(policy).toContain("https://avatars.githubusercontent.com");
+    expect(policy).toContain("https://*.googleusercontent.com");
+    expect(policy).toContain("https://accounts.google.com");
     expect(policy).toContain("https://sse-web-prod.s3.us-east-2.amazonaws.com");
     expect(policy).toContain(
       "connect-src 'self' https://api.github.com https://*.s3.amazonaws.com https://*.amazonaws.com https://sse-web-prod.s3.us-east-2.amazonaws.com"

--- a/next/lib/securityHeaders.js
+++ b/next/lib/securityHeaders.js
@@ -43,7 +43,7 @@ function buildContentSecurityPolicy({ production, nonce } = {}) {
         "'self'",
         "data:",
         "blob:",
-        "https://lh3.googleusercontent.com",
+        "https://*.googleusercontent.com",
         ...s3Origins,
         "https://source.boringavatars.com",
         "https://dummyimage.com",
@@ -61,7 +61,7 @@ function buildContentSecurityPolicy({ production, nonce } = {}) {
     ["frame-src", ["https://calendar.google.com"]],
     ["object-src", ["'none'"]],
     ["base-uri", ["'self'"]],
-    ["form-action", ["'self'"]],
+    ["form-action", ["'self'", "https://accounts.google.com"]],
     ["frame-ancestors", ["'none'"]],
     ["upgrade-insecure-requests", []],
   ];


### PR DESCRIPTION
## Summary
- Widen `img-src` from `lh3.googleusercontent.com` to `*.googleusercontent.com` to cover all Google profile image subdomains
- Add `https://accounts.google.com` to `form-action` so the NextAuth sign-in OAuth redirect is not blocked when CSP is enforced on prod

## Context
CSP is report-only on dev but enforced on prod, so these violations only cause actual breakage on `sse.rit.edu`. The sign-in form POST to `/api/auth/signin/google` redirects to `accounts.google.com`, which `form-action 'self'` blocks.

## Test plan
- [ ] Verify Google sign-in works on prod after deploy
- [ ] Verify profile images load without CSP violations
- [ ] `npx vitest run __tests__/securityHeaders.test.ts` passes