### PR TITLE
Fix amendment deployment flow and GitHub App auth

### DIFF
--- a/documentation/EnvironmentSetup.md
+++ b/documentation/EnvironmentSetup.md
@@ -47,7 +47,11 @@ DATABASE_URL="postgresql://postgres:postgres@localhost:5432/ssequel_dev"
 NEXTAUTH_URL="http://localhost:3000"
 NEXTAUTH_SECRET="replace-with-a-long-random-secret"
 SESSION_COOKIE_NAME="next-auth.session-token"
-GITHUB_PAT="server-side GitHub PAT for constitution amendments"
+GITHUB_APP_ID=""
+GITHUB_APP_PRIVATE_KEY=""
+GITHUB_APP_INSTALLATION_ID=""
+GITHUB_WEBHOOK_SECRET=""
+GITHUB_PAT=""
 
 # Google OAuth
 GOOGLE_CLIENT_ID=""
@@ -123,9 +127,19 @@ You do **not** need PostgreSQL installed directly on your computer if you use Do
 
 If you are using the constitution amendment workflow:
 
-- Create a server-side GitHub PAT with `repo` scope for write access to `rit-sse/governing-docs`.
-- Set `GITHUB_PAT` in the runtime environment for the Next.js container.
-- Keep this token out of source control and never expose it in client-side code.
+- Preferred: create a private GitHub App installed on `rit-sse/governing-docs`.
+- Grant repository permissions:
+  - `Contents: Read and write`
+  - `Pull requests: Read and write`
+- Set these runtime env vars on the Next.js container:
+  - `GITHUB_APP_ID`
+  - `GITHUB_APP_PRIVATE_KEY`
+  - `GITHUB_WEBHOOK_SECRET`
+- Optional:
+  - `GITHUB_APP_INSTALLATION_ID` if you want to pin the installation instead of letting the app auto-discover its installation on `rit-sse/governing-docs`
+- Legacy fallback:
+  - `GITHUB_PAT` still works if GitHub App env vars are not set, but the GitHub App flow is the deployment target going forward.
+- Keep all secrets out of source control and never expose them in client-side code.
 
 Example compose-style deployment snippet:
 
@@ -133,7 +147,10 @@ Example compose-style deployment snippet:
 services:
   website:
     environment:
-      GITHUB_PAT: ${GITHUB_PAT}
+      GITHUB_APP_ID: ${GITHUB_APP_ID}
+      GITHUB_APP_PRIVATE_KEY: ${GITHUB_APP_PRIVATE_KEY}
+      GITHUB_WEBHOOK_SECRET: ${GITHUB_WEBHOOK_SECRET}
+      GITHUB_APP_INSTALLATION_ID: ${GITHUB_APP_INSTALLATION_ID}
 ```
 
 ## Setting up Google OAuth

--- a/next/.env.example
+++ b/next/.env.example
@@ -5,6 +5,11 @@ DATABASE_URL="postgresql://postgres:postgres@localhost:5432/ssequel_dev"
 NEXTAUTH_URL="http://localhost:3000"
 NEXTAUTH_SECRET="replace-with-a-long-random-secret"
 SESSION_COOKIE_NAME="next-auth.session-token"
+GITHUB_APP_ID=""
+GITHUB_APP_PRIVATE_KEY=""
+GITHUB_APP_INSTALLATION_ID=""
+GITHUB_WEBHOOK_SECRET=""
+GITHUB_PAT=""
 
 # Google OAuth
 GOOGLE_CLIENT_ID=""

--- a/next/__tests__/amendments.route.test.ts
+++ b/next/__tests__/amendments.route.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockGetActorFromRequest,
+  mockComputeVoteSummary,
+  mockGetActiveMemberCount,
+  mockCreateAmendmentPR,
+  mockFetchConstitutionSnapshot,
+  mockAmendmentCreate,
+  mockAmendmentFindUnique,
+  mockAmendmentUpdate,
+  mockAmendmentVoteFindMany,
+  mockOfficerPositionCount,
+} = vi.hoisted(() => ({
+  mockGetActorFromRequest: vi.fn(),
+  mockComputeVoteSummary: vi.fn(),
+  mockGetActiveMemberCount: vi.fn(),
+  mockCreateAmendmentPR: vi.fn(),
+  mockFetchConstitutionSnapshot: vi.fn(),
+  mockAmendmentCreate: vi.fn(),
+  mockAmendmentFindUnique: vi.fn(),
+  mockAmendmentUpdate: vi.fn(),
+  mockAmendmentVoteFindMany: vi.fn(),
+  mockOfficerPositionCount: vi.fn(),
+}));
+
+vi.mock("@/lib/services/amendmentService", () => ({
+  getActorFromRequest: mockGetActorFromRequest,
+  computeVoteSummary: mockComputeVoteSummary,
+  getActiveMemberCount: mockGetActiveMemberCount,
+  getActivePrimaryOfficerCount: vi.fn(),
+  computePrimaryReviewResult: vi.fn(),
+}));
+
+vi.mock("@/lib/services/githubAmendmentService", () => ({
+  buildAmendmentBranchName: vi.fn(() => "amendment-55-retry-branch"),
+  createAmendmentPR: mockCreateAmendmentPR,
+  fetchConstitutionSnapshot: mockFetchConstitutionSnapshot,
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    amendment: {
+      create: mockAmendmentCreate,
+      findUnique: mockAmendmentFindUnique,
+      update: mockAmendmentUpdate,
+    },
+    amendmentVote: {
+      findMany: mockAmendmentVoteFindMany,
+    },
+    officerPosition: {
+      count: mockOfficerPositionCount,
+    },
+  },
+}));
+
+import { POST } from "@/app/api/amendments/route";
+import { PATCH } from "@/app/api/amendments/[id]/route";
+import { POST as resubmitPOST } from "@/app/api/amendments/[id]/resubmit-pr/route";
+
+describe("/api/amendments routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetActorFromRequest.mockResolvedValue({
+      id: 7,
+      isMember: true,
+      isPrimary: true,
+      isSeAdmin: false,
+    });
+    mockComputeVoteSummary.mockReturnValue({
+      totalVotes: 0,
+      approveVotes: 0,
+      rejectVotes: 0,
+    });
+    mockGetActiveMemberCount.mockResolvedValue(30);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("POST persists the client baseline when GitHub snapshot creation fails", async () => {
+    mockFetchConstitutionSnapshot.mockRejectedValue(
+      new Error("github offline"),
+    );
+    mockCreateAmendmentPR.mockRejectedValue(new Error("pr create failed"));
+    mockAmendmentCreate.mockResolvedValue({ id: 42 });
+    mockAmendmentFindUnique.mockResolvedValue({
+      id: 42,
+      title: "Presidential Running Mate Appointment",
+      status: "PRIMARY_REVIEW",
+      githubPrNumber: null,
+      githubBranch: null,
+    });
+
+    const res = await POST(
+      new Request("http://localhost/api/amendments", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          title: "Presidential Running Mate Appointment",
+          description: "Adds a VP appointment flow.",
+          originalContent: "# SSE Constitution\n\nCurrent text",
+          proposedContent: "# SSE Constitution\n\nUpdated text",
+          isSemanticChange: true,
+        }),
+      }) as any,
+    );
+
+    expect(res.status).toBe(201);
+    expect(mockAmendmentCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        originalContent: "# SSE Constitution\n\nCurrent text",
+        proposedContent: "# SSE Constitution\n\nUpdated text",
+      }),
+    });
+  });
+
+  it("PATCH allows primary officers to edit the voting window while voting is live", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-15T16:30:00.000Z"));
+
+    mockAmendmentFindUnique.mockResolvedValue({
+      id: 12,
+      status: "VOTING",
+      authorId: 7,
+      publishedAt: new Date("2026-04-15T12:00:00.000Z"),
+      votingOpenedAt: new Date("2026-04-15T13:00:00.000Z"),
+    });
+    mockAmendmentUpdate.mockResolvedValue({
+      id: 12,
+      status: "VOTING",
+    });
+
+    const res = await PATCH(
+      new Request("http://localhost/api/amendments/12", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          status: "VOTING",
+          votingDurationHours: 72,
+          resetVotingWindowFromNow: true,
+        }),
+      }) as any,
+      { params: Promise.resolve({ id: "12" }) },
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockAmendmentUpdate).toHaveBeenCalledWith({
+      where: { id: 12 },
+      data: expect.objectContaining({
+        status: "VOTING",
+        votingDurationHours: 72,
+        votingClosedAt: null,
+        votingEndsAt: new Date("2026-04-18T16:30:00.000Z"),
+      }),
+    });
+  });
+
+  it("POST can re-submit a missing amendment PR for the author", async () => {
+    mockGetActorFromRequest.mockResolvedValue({
+      id: 7,
+      isMember: true,
+      isPrimary: false,
+      isSeAdmin: false,
+    });
+    mockAmendmentFindUnique.mockResolvedValue({
+      id: 55,
+      title: "Presidential Running Mate Appointment",
+      description: "Adds a VP appointment flow.",
+      proposedContent: "# SSE Constitution\n\nUpdated text",
+      authorId: 7,
+      githubPrNumber: null,
+      status: "PRIMARY_REVIEW",
+    });
+    mockCreateAmendmentPR.mockResolvedValue({
+      branch: "amendment-55-retry-branch",
+      prNumber: 123,
+      prUrl: "https://github.com/rit-sse/governing-docs/pull/123",
+      originalContent: "# SSE Constitution\n\nCurrent text",
+    });
+    mockAmendmentUpdate.mockResolvedValue({
+      id: 55,
+      githubBranch: "amendment-55-retry-branch",
+      githubPrNumber: 123,
+      originalContent: "# SSE Constitution\n\nCurrent text",
+    });
+
+    const res = await resubmitPOST(
+      new Request("http://localhost/api/amendments/55/resubmit-pr", {
+        method: "POST",
+      }) as any,
+      { params: Promise.resolve({ id: "55" }) },
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockCreateAmendmentPR).toHaveBeenCalledWith({
+      title: "Presidential Running Mate Appointment",
+      description: "Adds a VP appointment flow.",
+      proposedContent: "# SSE Constitution\n\nUpdated text",
+      proposedBy: "Member #7",
+      branchName: "amendment-55-retry-branch",
+    });
+    expect(mockAmendmentUpdate).toHaveBeenCalledWith({
+      where: { id: 55 },
+      data: {
+        githubBranch: "amendment-55-retry-branch",
+        githubPrNumber: 123,
+        originalContent: "# SSE Constitution\n\nCurrent text",
+      },
+      select: {
+        id: true,
+        githubBranch: true,
+        githubPrNumber: true,
+        originalContent: true,
+      },
+    });
+  });
+});

--- a/next/__tests__/amendments.route.test.ts
+++ b/next/__tests__/amendments.route.test.ts
@@ -83,9 +83,7 @@ describe("/api/amendments routes", () => {
     mockFetchConstitutionSnapshot.mockRejectedValue(
       new Error("github offline"),
     );
-    mockCreateAmendmentPR.mockRejectedValue(new Error("pr create failed"));
-    mockAmendmentCreate.mockResolvedValue({ id: 42 });
-    mockAmendmentFindUnique.mockResolvedValue({
+    mockAmendmentCreate.mockResolvedValue({
       id: 42,
       title: "Presidential Running Mate Appointment",
       status: "PRIMARY_REVIEW",
@@ -113,7 +111,15 @@ describe("/api/amendments routes", () => {
         originalContent: "# SSE Constitution\n\nCurrent text",
         proposedContent: "# SSE Constitution\n\nUpdated text",
       }),
+      select: {
+        id: true,
+        title: true,
+        status: true,
+        githubPrNumber: true,
+        githubBranch: true,
+      },
     });
+    expect(mockCreateAmendmentPR).not.toHaveBeenCalled();
   });
 
   it("PATCH allows primary officers to edit the voting window while voting is live", async () => {
@@ -157,6 +163,123 @@ describe("/api/amendments routes", () => {
     });
   });
 
+  it("PATCH allows quorum-stage text edits before voting opens", async () => {
+    mockFetchConstitutionSnapshot.mockResolvedValue({
+      content: "# SSE Constitution\n\nCurrent baseline",
+      sha: "baseline-sha",
+    });
+    mockAmendmentFindUnique.mockResolvedValue({
+      id: 21,
+      status: "PRIMARY_REVIEW",
+      authorId: 7,
+      title: "Original title",
+      description: "Original description",
+      proposedContent: "# SSE Constitution\n\nOld text",
+      githubPrNumber: null,
+      publishedAt: new Date("2026-04-15T12:00:00.000Z"),
+      votingOpenedAt: null,
+    });
+    mockAmendmentUpdate.mockResolvedValue({
+      id: 21,
+      status: "PRIMARY_REVIEW",
+      title: "Updated title",
+      description: "Updated description",
+      proposedContent: "# SSE Constitution\n\nUpdated text",
+    });
+
+    const res = await PATCH(
+      new Request("http://localhost/api/amendments/21", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          title: "Updated title",
+          description: "Updated description",
+          proposedContent: "# SSE Constitution\n\nUpdated text",
+        }),
+      }) as any,
+      { params: Promise.resolve({ id: "21" }) },
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockAmendmentUpdate).toHaveBeenCalledWith({
+      where: { id: 21 },
+      data: expect.objectContaining({
+        title: "Updated title",
+        description: "Updated description",
+        proposedContent: "# SSE Constitution\n\nUpdated text",
+        originalContent: "# SSE Constitution\n\nCurrent baseline",
+      }),
+    });
+    expect(mockCreateAmendmentPR).not.toHaveBeenCalled();
+  });
+
+  it("PATCH opens voting and creates the GitHub PR after quorum passes", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-15T18:00:00.000Z"));
+
+    mockAmendmentFindUnique.mockResolvedValue({
+      id: 34,
+      status: "PRIMARY_REVIEW",
+      authorId: 7,
+      title: "Presidential Running Mate Appointment",
+      description: "Adds a VP appointment flow.",
+      proposedContent: "# SSE Constitution\n\nUpdated text",
+      githubPrNumber: null,
+      publishedAt: new Date("2026-04-15T12:00:00.000Z"),
+      votingOpenedAt: null,
+    });
+    mockAmendmentVoteFindMany.mockResolvedValue([
+      { approve: true },
+      { approve: true },
+    ]);
+    mockOfficerPositionCount.mockResolvedValue(3);
+    mockCreateAmendmentPR.mockResolvedValue({
+      branch: "amendment-55-retry-branch",
+      prNumber: 123,
+      prUrl: "https://github.com/rit-sse/governing-docs/pull/123",
+      originalContent: "# SSE Constitution\n\nCurrent text",
+    });
+    mockAmendmentUpdate.mockResolvedValue({
+      id: 34,
+      status: "VOTING",
+      githubPrNumber: 123,
+      githubBranch: "amendment-55-retry-branch",
+    });
+
+    const res = await PATCH(
+      new Request("http://localhost/api/amendments/34", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          status: "VOTING",
+          votingDurationHours: 72,
+        }),
+      }) as any,
+      { params: Promise.resolve({ id: "34" }) },
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockCreateAmendmentPR).toHaveBeenCalledWith({
+      title: "Presidential Running Mate Appointment",
+      description: "Adds a VP appointment flow.",
+      proposedContent: "# SSE Constitution\n\nUpdated text",
+      proposedBy: "Member #7",
+      branchName: "amendment-55-retry-branch",
+    });
+    expect(mockAmendmentUpdate).toHaveBeenCalledWith({
+      where: { id: 34 },
+      data: expect.objectContaining({
+        status: "VOTING",
+        primaryReviewClosedAt: new Date("2026-04-15T18:00:00.000Z"),
+        votingOpenedAt: new Date("2026-04-15T18:00:00.000Z"),
+        votingDurationHours: 72,
+        githubPrNumber: 123,
+        githubBranch: "amendment-55-retry-branch",
+        originalContent: "# SSE Constitution\n\nCurrent text",
+      }),
+    });
+  });
+
   it("POST can re-submit a missing amendment PR for the author", async () => {
     mockGetActorFromRequest.mockResolvedValue({
       id: 7,
@@ -171,7 +294,7 @@ describe("/api/amendments routes", () => {
       proposedContent: "# SSE Constitution\n\nUpdated text",
       authorId: 7,
       githubPrNumber: null,
-      status: "PRIMARY_REVIEW",
+      status: "VOTING",
     });
     mockCreateAmendmentPR.mockResolvedValue({
       branch: "amendment-55-retry-branch",

--- a/next/__tests__/githubAmendmentService.test.ts
+++ b/next/__tests__/githubAmendmentService.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const signMock = vi.fn(() => "app-jwt");
+
+vi.mock("jsonwebtoken", () => ({
+  default: {
+    sign: signMock,
+  },
+}));
+
+describe("githubAmendmentService auth", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.unstubAllGlobals();
+  });
+
+  it("uses GitHub App installation auth when app env is configured", async () => {
+    process.env.GITHUB_APP_ID = "3394606";
+    process.env.GITHUB_APP_PRIVATE_KEY =
+      "-----BEGIN RSA PRIVATE KEY-----\\nline-one\\nline-two\\n-----END RSA PRIVATE KEY-----";
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: 987654 }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            token: "installation-token",
+            expires_at: "2099-01-01T00:00:00.000Z",
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            content: Buffer.from("Constitution text").toString("base64"),
+            sha: "constitution-sha",
+            encoding: "base64",
+          }),
+          { status: 200 },
+        ),
+      );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { fetchConstitutionSnapshot } = await import(
+      "@/lib/services/githubAmendmentService"
+    );
+    const snapshot = await fetchConstitutionSnapshot();
+
+    expect(snapshot).toEqual({
+      content: "Constitution text",
+      sha: "constitution-sha",
+    });
+    expect(signMock).toHaveBeenCalledTimes(2);
+    expect(signMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        iss: "3394606",
+      }),
+      expect.stringContaining("\n"),
+      expect.objectContaining({
+        algorithm: "RS256",
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.github.com/repos/rit-sse/governing-docs/installation",
+      expect.objectContaining({
+        headers: expect.any(Headers),
+        method: "GET",
+      }),
+    );
+    expect(
+      (fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)?.headers,
+    ).toEqual(
+      expect.objectContaining({
+        get: expect.any(Function),
+      }),
+    );
+    expect(
+      (
+        (fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)
+          ?.headers as Headers
+      ).get("Authorization"),
+    ).toBe("Bearer app-jwt");
+    expect(
+      (
+        (fetchMock.mock.calls[1]?.[1] as RequestInit | undefined)
+          ?.headers as Headers
+      ).get("Authorization"),
+    ).toBe("Bearer app-jwt");
+    expect(
+      (
+        (fetchMock.mock.calls[2]?.[1] as RequestInit | undefined)
+          ?.headers as Headers
+      ).get("Authorization"),
+    ).toBe("Bearer installation-token");
+  });
+
+  it("falls back to GITHUB_PAT when no app env is configured", async () => {
+    process.env.GITHUB_PAT = "legacy-token";
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          content: Buffer.from("Constitution text").toString("base64"),
+          sha: "constitution-sha",
+          encoding: "base64",
+        }),
+        { status: 200 },
+      ),
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { fetchConstitutionSnapshot } = await import(
+      "@/lib/services/githubAmendmentService"
+    );
+    await fetchConstitutionSnapshot();
+
+    expect(signMock).not.toHaveBeenCalled();
+    expect(
+      (
+        (fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)
+          ?.headers as Headers
+      ).get("Authorization"),
+    ).toBe("Bearer legacy-token");
+  });
+});

--- a/next/app/(main)/about/constitution/amendments/page.tsx
+++ b/next/app/(main)/about/constitution/amendments/page.tsx
@@ -46,7 +46,7 @@ export default async function AmendmentsListPage() {
   if (authLevel.userId) {
     for (const amendment of amendments) {
       const vote = amendment.votes.find(
-        (v) => v.userId === authLevel.userId && v.phase === "VOTING"
+        (v) => v.userId === authLevel.userId && v.phase === "VOTING",
       );
       if (vote) {
         userVotes[amendment.id] = vote.approve;
@@ -55,26 +55,30 @@ export default async function AmendmentsListPage() {
   }
 
   const emptyRole = authLevel.isSeAdmin
-    ? "seAdmin" as const
+    ? ("seAdmin" as const)
     : authLevel.isPrimary
-      ? "primary" as const
+      ? ("primary" as const)
       : authLevel.isOfficer
-        ? "officer" as const
+        ? ("officer" as const)
         : authLevel.isMember
-          ? "member" as const
+          ? ("member" as const)
           : authLevel.isUser
-            ? "signedIn" as const
-            : "anonymous" as const;
+            ? ("signedIn" as const)
+            : ("anonymous" as const);
 
-  const activeRows = rows.filter((r) => r.status !== "WITHDRAWN" && r.status !== "REJECTED");
-  const withdrawnRows = rows.filter((r) => r.status === "WITHDRAWN" || r.status === "REJECTED");
+  const activeRows = rows.filter(
+    (r) => r.status !== "WITHDRAWN" && r.status !== "REJECTED",
+  );
+  const withdrawnRows = rows.filter(
+    (r) => r.status === "WITHDRAWN" || r.status === "REJECTED",
+  );
 
   return (
-    <section className="w-full max-w-6xl px-2 md:px-4">
+    <section className="w-full max-w-6xl px-3 sm:px-4">
       {/* Page header */}
-      <div className="py-4 flex flex-wrap gap-3 justify-between items-center">
+      <div className="flex flex-col gap-3 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h1 className="text-3xl font-display font-bold tracking-tight">
+          <h1 className="text-2xl font-display font-bold tracking-tight sm:text-3xl">
             Constitutional Amendments
           </h1>
           <p className="text-sm text-muted-foreground mt-1">
@@ -82,8 +86,11 @@ export default async function AmendmentsListPage() {
           </p>
         </div>
         {authLevel.isMember && (
-          <Button asChild>
-            <Link href="/about/constitution/amendments/new" className="flex items-center gap-2">
+          <Button asChild className="w-full sm:w-auto">
+            <Link
+              href="/about/constitution/amendments/new"
+              className="flex items-center gap-2"
+            >
               <Plus className="h-4 w-4" />
               Propose Amendment
             </Link>
@@ -98,7 +105,9 @@ export default async function AmendmentsListPage() {
         ) : (
           <>
             {activeRows.length === 0 ? (
-              <p className="text-sm text-muted-foreground py-4 text-center">No active amendments right now.</p>
+              <p className="text-sm text-muted-foreground py-4 text-center">
+                No active amendments right now.
+              </p>
             ) : (
               <div className="space-y-3">
                 {activeRows.map((amendment) => (

--- a/next/app/api/amendments/[id]/resubmit-pr/route.ts
+++ b/next/app/api/amendments/[id]/resubmit-pr/route.ts
@@ -54,12 +54,11 @@ export async function POST(
   }
 
   if (
-    amendment.status === AmendmentStatus.MERGED ||
-    amendment.status === AmendmentStatus.WITHDRAWN ||
-    amendment.status === AmendmentStatus.REJECTED
+    amendment.status !== AmendmentStatus.VOTING &&
+    amendment.status !== AmendmentStatus.APPROVED
   ) {
     return new Response(
-      "This amendment is no longer eligible for PR re-submission",
+      "A PR can only be created after quorum has passed and member voting is open.",
       { status: 409 },
     );
   }

--- a/next/app/api/amendments/[id]/resubmit-pr/route.ts
+++ b/next/app/api/amendments/[id]/resubmit-pr/route.ts
@@ -1,0 +1,103 @@
+import prisma from "@/lib/prisma";
+import { AmendmentStatus } from "@prisma/client";
+import { NextRequest } from "next/server";
+import { getActorFromRequest } from "@/lib/services/amendmentService";
+import {
+  buildAmendmentBranchName,
+  createAmendmentPR,
+} from "@/lib/services/githubAmendmentService";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const amendmentId = Number(id);
+  if (Number.isNaN(amendmentId)) {
+    return new Response("Invalid amendment id", { status: 422 });
+  }
+
+  const actor = await getActorFromRequest(request);
+  if (!actor) {
+    return new Response("Authentication required", { status: 401 });
+  }
+
+  const amendment = await prisma.amendment.findUnique({
+    where: { id: amendmentId },
+    select: {
+      id: true,
+      title: true,
+      description: true,
+      proposedContent: true,
+      authorId: true,
+      githubPrNumber: true,
+      status: true,
+    },
+  });
+  if (!amendment) {
+    return new Response("Amendment not found", { status: 404 });
+  }
+
+  if (!actor.isPrimary && !actor.isSeAdmin && amendment.authorId !== actor.id) {
+    return new Response(
+      "Only the author, a primary officer, or an SE admin can re-submit a PR",
+      { status: 403 },
+    );
+  }
+
+  if (amendment.githubPrNumber) {
+    return new Response("This amendment already has a linked pull request", {
+      status: 409,
+    });
+  }
+
+  if (
+    amendment.status === AmendmentStatus.MERGED ||
+    amendment.status === AmendmentStatus.WITHDRAWN ||
+    amendment.status === AmendmentStatus.REJECTED
+  ) {
+    return new Response(
+      "This amendment is no longer eligible for PR re-submission",
+      { status: 409 },
+    );
+  }
+
+  const branchName = buildAmendmentBranchName(amendment.title, amendment.id);
+  const proposedBy = `Member #${amendment.authorId}`;
+  const prBody =
+    amendment.description ||
+    `${amendment.title}\n\nAmendment proposal by ${proposedBy}.`;
+
+  try {
+    const { prNumber, originalContent } = await createAmendmentPR({
+      title: amendment.title,
+      description: prBody,
+      proposedContent: amendment.proposedContent,
+      proposedBy,
+      branchName,
+    });
+
+    const updated = await prisma.amendment.update({
+      where: { id: amendment.id },
+      data: {
+        githubBranch: branchName,
+        githubPrNumber: prNumber,
+        originalContent,
+      },
+      select: {
+        id: true,
+        githubBranch: true,
+        githubPrNumber: true,
+        originalContent: true,
+      },
+    });
+
+    return Response.json(updated);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to re-submit PR";
+    return new Response(message, { status: 500 });
+  }
+}

--- a/next/app/api/amendments/[id]/route.ts
+++ b/next/app/api/amendments/[id]/route.ts
@@ -4,10 +4,13 @@ import { NextRequest } from "next/server";
 import {
   computeVoteSummary,
   getActiveMemberCount,
-  getActivePrimaryOfficerCount,
-  computePrimaryReviewResult,
   getActorFromRequest,
 } from "@/lib/services/amendmentService";
+import {
+  buildAmendmentBranchName,
+  createAmendmentPR,
+  fetchConstitutionSnapshot,
+} from "@/lib/services/githubAmendmentService";
 
 export const dynamic = "force-dynamic";
 
@@ -31,6 +34,26 @@ function parseVotingDurationHours(value: unknown): number | null {
     return null;
   }
   return value;
+}
+
+function sanitizeText(input: unknown): string | null {
+  if (typeof input !== "string") return null;
+  return input.trim();
+}
+
+function canEditAmendmentContent(
+  actor: { isPrimary: boolean; isSeAdmin: boolean; id: number } | null,
+  amendment: { authorId: number; status: AmendmentStatus },
+) {
+  if (!actor) {
+    return false;
+  }
+
+  if (amendment.status !== "PRIMARY_REVIEW") {
+    return false;
+  }
+
+  return actor.isPrimary || actor.isSeAdmin || amendment.authorId === actor.id;
 }
 
 export async function GET(
@@ -230,6 +253,9 @@ export async function PATCH(
     status?: string;
     votingDurationHours?: number;
     resetVotingWindowFromNow?: boolean;
+    title?: unknown;
+    description?: unknown;
+    proposedContent?: unknown;
   };
   try {
     body = await request.json();
@@ -237,9 +263,25 @@ export async function PATCH(
     return new Response("Invalid JSON", { status: 422 });
   }
 
-  const requestedStatus = sanitizeStatus(body.status ?? null);
-  if (!requestedStatus) {
+  const requestedStatus = body.status
+    ? sanitizeStatus(body.status ?? null)
+    : null;
+  if (body.status && !requestedStatus) {
     return new Response("Invalid status value", { status: 422 });
+  }
+
+  const nextTitle = sanitizeText(body.title);
+  const nextDescription = sanitizeText(body.description);
+  const nextProposedContent = sanitizeText(body.proposedContent);
+  const wantsContentEdit =
+    nextTitle !== null ||
+    nextDescription !== null ||
+    nextProposedContent !== null;
+
+  if (!requestedStatus && !wantsContentEdit) {
+    return new Response("Provide a valid status change or amendment edits", {
+      status: 422,
+    });
   }
 
   const amendment = await prisma.amendment.findUnique({
@@ -248,6 +290,10 @@ export async function PATCH(
       id: true,
       status: true,
       authorId: true,
+      title: true,
+      description: true,
+      proposedContent: true,
+      githubPrNumber: true,
       publishedAt: true,
       votingOpenedAt: true,
     },
@@ -256,7 +302,10 @@ export async function PATCH(
     return new Response("Amendment not found", { status: 404 });
   }
 
-  if (!canChangeStatus(actor ?? null, amendment, requestedStatus)) {
+  if (
+    requestedStatus &&
+    !canChangeStatus(actor ?? null, amendment, requestedStatus)
+  ) {
     return new Response(
       "Only primary officers, SE admins, or the author may update this amendment",
       { status: 403 },
@@ -264,7 +313,45 @@ export async function PATCH(
   }
 
   const now = new Date();
-  const updateData: Record<string, unknown> = { status: requestedStatus };
+  const updateData: Record<string, unknown> = {};
+
+  if (wantsContentEdit) {
+    if (!canEditAmendmentContent(actor ?? null, amendment)) {
+      return new Response(
+        "Only the author, a primary officer, or an SE admin can edit this amendment during quorum.",
+        { status: 403 },
+      );
+    }
+
+    if (nextTitle !== null) {
+      if (!nextTitle) {
+        return new Response("title cannot be empty", { status: 422 });
+      }
+      updateData.title = nextTitle;
+    }
+
+    if (nextDescription !== null) {
+      updateData.description = nextDescription;
+    }
+
+    if (nextProposedContent !== null) {
+      if (!nextProposedContent) {
+        return new Response("proposedContent cannot be empty", { status: 422 });
+      }
+      updateData.proposedContent = nextProposedContent;
+    }
+
+    try {
+      const snapshot = await fetchConstitutionSnapshot();
+      updateData.originalContent = snapshot.content;
+    } catch {
+      // Keep the existing baseline if GitHub is unavailable while editing.
+    }
+  }
+
+  if (requestedStatus) {
+    updateData.status = requestedStatus;
+  }
 
   if (requestedStatus === "OPEN" && amendment.status !== "OPEN") {
     updateData.publishedAt = now;
@@ -321,6 +408,40 @@ export async function PATCH(
     updateData.votingOpenedAt = now;
     updateData.votingDurationHours = hours;
     updateData.votingEndsAt = new Date(now.getTime() + hours * 60 * 60 * 1000);
+
+    if (!amendment.githubPrNumber) {
+      const branchName = buildAmendmentBranchName(amendment.title, amendment.id);
+      const proposedBy = `Member #${amendment.authorId}`;
+      const prBody =
+        amendment.description ||
+        `${amendment.title}\n\nAmendment proposal by ${proposedBy}.`;
+
+      try {
+        const { prNumber, originalContent } = await createAmendmentPR({
+          title: amendment.title,
+          description: prBody,
+          proposedContent:
+            (typeof updateData.proposedContent === "string"
+              ? updateData.proposedContent
+              : amendment.proposedContent) ?? amendment.proposedContent,
+          proposedBy,
+          branchName,
+        });
+
+        updateData.githubBranch = branchName;
+        updateData.githubPrNumber = prNumber;
+        updateData.originalContent = originalContent;
+      } catch {
+        try {
+          const snapshot = await fetchConstitutionSnapshot();
+          updateData.originalContent = snapshot.content;
+        } catch {
+          // Keep the current baseline if GitHub is unavailable.
+        }
+        updateData.prCreationWarning =
+          "Member voting opened, but the GitHub PR could not be created. Use Create PR to retry.";
+      }
+    }
   }
 
   // VOTING → VOTING (edit the existing voting window without changing status)
@@ -383,10 +504,19 @@ export async function PATCH(
     updateData.votingClosedAt = now;
   }
 
+  const prCreationWarning =
+    typeof updateData.prCreationWarning === "string"
+      ? (updateData.prCreationWarning as string)
+      : null;
+  delete updateData.prCreationWarning;
+
   const updated = await prisma.amendment.update({
     where: { id: amendmentId },
     data: updateData,
   });
 
-  return Response.json(updated);
+  return Response.json({
+    ...updated,
+    prCreationWarning,
+  });
 }

--- a/next/app/api/amendments/[id]/route.ts
+++ b/next/app/api/amendments/[id]/route.ts
@@ -21,7 +21,22 @@ function sanitizeStatus(value: string | null): AmendmentStatus | null {
   return null;
 }
 
-export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+function parseVotingDurationHours(value: unknown): number | null {
+  if (
+    typeof value !== "number" ||
+    Number.isNaN(value) ||
+    value < 1 ||
+    value > 336
+  ) {
+    return null;
+  }
+  return value;
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
   const { id } = await params;
   const amendmentId = Number(id);
   if (Number.isNaN(amendmentId)) {
@@ -41,7 +56,14 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
         },
       },
       votes: {
-        select: { id: true, userId: true, approve: true, phase: true, officerPositionId: true, createdAt: true },
+        select: {
+          id: true,
+          userId: true,
+          approve: true,
+          phase: true,
+          officerPositionId: true,
+          createdAt: true,
+        },
       },
       comments: {
         select: {
@@ -67,20 +89,25 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 
   // Partition votes by phase
   const memberVotes = amendment.votes.filter((v) => v.phase === "VOTING");
-  const primaryReviewVotes = amendment.votes.filter((v) => v.phase === "PRIMARY_REVIEW");
+  const primaryReviewVotes = amendment.votes.filter(
+    (v) => v.phase === "PRIMARY_REVIEW",
+  );
 
   // Member vote summary (VOTING phase only)
   const voteSummary = computeVoteSummary(memberVotes);
   const totalActiveMembers = await getActiveMemberCount();
   const requiredVotingParticipation = Math.ceil(totalActiveMembers * (2 / 3));
   const quorumAchieved =
-    voteSummary.totalVotes >= requiredVotingParticipation || requiredVotingParticipation === 0;
+    voteSummary.totalVotes >= requiredVotingParticipation ||
+    requiredVotingParticipation === 0;
   const approvingVotesRequired = Math.ceil(voteSummary.totalVotes * (2 / 3));
-  const hasSupermajority = voteSummary.totalVotes > 0 && voteSummary.approveVotes >= approvingVotesRequired;
+  const hasSupermajority =
+    voteSummary.totalVotes > 0 &&
+    voteSummary.approveVotes >= approvingVotesRequired;
 
   // User's member vote
   const userVote = actor?.id
-    ? memberVotes.find((vote) => vote.userId === actor.id)?.approve ?? null
+    ? (memberVotes.find((vote) => vote.userId === actor.id)?.approve ?? null)
     : null;
 
   // Build position-level primary review data
@@ -98,7 +125,11 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
   });
 
   const positionSlots = allPrimaryPositions.map((pos) => {
-    const vote = primaryReviewVotes.find((v) => v.phase === "PRIMARY_REVIEW" && (v as { officerPositionId?: number }).officerPositionId === pos.id);
+    const vote = primaryReviewVotes.find(
+      (v) =>
+        v.phase === "PRIMARY_REVIEW" &&
+        (v as { officerPositionId?: number }).officerPositionId === pos.id,
+    );
     const holder = pos.officers[0]?.user ?? null;
     return {
       positionId: pos.id,
@@ -113,7 +144,8 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
   const votedCount = positionSlots.filter((s) => s.voted).length;
   const approveCount = positionSlots.filter((s) => s.approve === true).length;
   const rejectCount = positionSlots.filter((s) => s.approve === false).length;
-  const quorumRequired = totalPositions === 0 ? 0 : Math.floor(totalPositions / 2) + 1;
+  const quorumRequired =
+    totalPositions === 0 ? 0 : Math.floor(totalPositions / 2) + 1;
   const quorumMet = votedCount >= quorumRequired;
 
   return Response.json({
@@ -174,14 +206,19 @@ function canChangeStatus(
   // SE Admin can only perform the final merge (APPROVED → MERGED is handled by merge route)
   // and withdraw amendments
   if (requestedStatus === "WITHDRAWN") {
-    return actor.isPrimary || actor.isSeAdmin || amendment.authorId === actor.id;
+    return (
+      actor.isPrimary || actor.isSeAdmin || amendment.authorId === actor.id
+    );
   }
 
   // All other status transitions require primary officer
   return actor.isPrimary;
 }
 
-export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
   const { id } = await params;
   const amendmentId = Number(id);
   if (Number.isNaN(amendmentId)) {
@@ -189,7 +226,11 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
   }
 
   const actor = await getActorFromRequest(request);
-  let body: { status?: string; votingDurationHours?: number };
+  let body: {
+    status?: string;
+    votingDurationHours?: number;
+    resetVotingWindowFromNow?: boolean;
+  };
   try {
     body = await request.json();
   } catch {
@@ -203,14 +244,23 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
 
   const amendment = await prisma.amendment.findUnique({
     where: { id: amendmentId },
-    select: { id: true, status: true, authorId: true, publishedAt: true },
+    select: {
+      id: true,
+      status: true,
+      authorId: true,
+      publishedAt: true,
+      votingOpenedAt: true,
+    },
   });
   if (!amendment) {
     return new Response("Amendment not found", { status: 404 });
   }
 
   if (!canChangeStatus(actor ?? null, amendment, requestedStatus)) {
-    return new Response("Only primary officers, SE admins, or the author may update this amendment", { status: 403 });
+    return new Response(
+      "Only primary officers, SE admins, or the author may update this amendment",
+      { status: 403 },
+    );
   }
 
   const now = new Date();
@@ -221,7 +271,10 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
   }
 
   // DRAFT/OPEN → PRIMARY_REVIEW
-  if (requestedStatus === "PRIMARY_REVIEW" && amendment.status !== "PRIMARY_REVIEW") {
+  if (
+    requestedStatus === "PRIMARY_REVIEW" &&
+    amendment.status !== "PRIMARY_REVIEW"
+  ) {
     updateData.primaryReviewOpenedAt = now;
     if (!amendment.publishedAt) {
       updateData.publishedAt = now;
@@ -231,14 +284,21 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
   // PRIMARY_REVIEW → VOTING (requires position-level quorum + majority approval + voting duration)
   if (requestedStatus === "VOTING" && amendment.status === "PRIMARY_REVIEW") {
     const primaryVotes = await prisma.amendmentVote.findMany({
-      where: { amendmentId, phase: "PRIMARY_REVIEW", officerPositionId: { not: null } },
+      where: {
+        amendmentId,
+        phase: "PRIMARY_REVIEW",
+        officerPositionId: { not: null },
+      },
       select: { approve: true },
     });
-    const totalPositions = await prisma.officerPosition.count({ where: { is_primary: true } });
+    const totalPositions = await prisma.officerPosition.count({
+      where: { is_primary: true },
+    });
     const votedCount = primaryVotes.length;
     const approveCount = primaryVotes.filter((v) => v.approve).length;
     const rejectCount = votedCount - approveCount;
-    const quorumRequired = totalPositions === 0 ? 0 : Math.floor(totalPositions / 2) + 1;
+    const quorumRequired =
+      totalPositions === 0 ? 0 : Math.floor(totalPositions / 2) + 1;
     const quorumMet = votedCount >= quorumRequired;
     const majorityApproves = quorumMet && approveCount > rejectCount;
 
@@ -249,8 +309,8 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       );
     }
 
-    const hours = body.votingDurationHours;
-    if (!hours || typeof hours !== "number" || hours < 1 || hours > 336) {
+    const hours = parseVotingDurationHours(body.votingDurationHours);
+    if (hours === null) {
       return new Response(
         "votingDurationHours must be a number between 1 and 336.",
         { status: 422 },
@@ -263,17 +323,44 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
     updateData.votingEndsAt = new Date(now.getTime() + hours * 60 * 60 * 1000);
   }
 
+  // VOTING → VOTING (edit the existing voting window without changing status)
+  if (requestedStatus === "VOTING" && amendment.status === "VOTING") {
+    const hours = parseVotingDurationHours(body.votingDurationHours);
+    if (hours === null) {
+      return new Response(
+        "votingDurationHours must be a number between 1 and 336.",
+        { status: 422 },
+      );
+    }
+
+    const baseTime = body.resetVotingWindowFromNow
+      ? now
+      : (amendment.votingOpenedAt ?? now);
+    updateData.votingDurationHours = hours;
+    updateData.votingEndsAt = new Date(
+      baseTime.getTime() + hours * 60 * 60 * 1000,
+    );
+    updateData.votingClosedAt = null;
+  }
+
   // PRIMARY_REVIEW → REJECTED (requires position-level quorum + majority rejection)
   if (requestedStatus === "REJECTED" && amendment.status === "PRIMARY_REVIEW") {
     const primaryVotes = await prisma.amendmentVote.findMany({
-      where: { amendmentId, phase: "PRIMARY_REVIEW", officerPositionId: { not: null } },
+      where: {
+        amendmentId,
+        phase: "PRIMARY_REVIEW",
+        officerPositionId: { not: null },
+      },
       select: { approve: true },
     });
-    const totalPositions = await prisma.officerPosition.count({ where: { is_primary: true } });
+    const totalPositions = await prisma.officerPosition.count({
+      where: { is_primary: true },
+    });
     const votedCount = primaryVotes.length;
     const approveCount = primaryVotes.filter((v) => v.approve).length;
     const rejectCount = votedCount - approveCount;
-    const quorumRequired = totalPositions === 0 ? 0 : Math.floor(totalPositions / 2) + 1;
+    const quorumRequired =
+      totalPositions === 0 ? 0 : Math.floor(totalPositions / 2) + 1;
     const quorumMet = votedCount >= quorumRequired;
     const majorityRejects = quorumMet && rejectCount >= approveCount;
 
@@ -289,7 +376,10 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
   }
 
   // VOTING → APPROVED/REJECTED
-  if ((requestedStatus === "APPROVED" || requestedStatus === "REJECTED") && amendment.status === "VOTING") {
+  if (
+    (requestedStatus === "APPROVED" || requestedStatus === "REJECTED") &&
+    amendment.status === "VOTING"
+  ) {
     updateData.votingClosedAt = now;
   }
 

--- a/next/app/api/amendments/route.ts
+++ b/next/app/api/amendments/route.ts
@@ -1,25 +1,17 @@
 import prisma from "@/lib/prisma";
 import { AmendmentStatus } from "@prisma/client";
 import { NextRequest } from "next/server";
-import { computeVoteSummary, getActorFromRequest } from "@/lib/services/amendmentService";
 import {
+  computeVoteSummary,
+  getActorFromRequest,
+} from "@/lib/services/amendmentService";
+import {
+  buildAmendmentBranchName,
   createAmendmentPR,
   fetchConstitutionSnapshot,
 } from "@/lib/services/githubAmendmentService";
 
 export const dynamic = "force-dynamic";
-
-function buildBranchName(title: string, amendmentId: number): string {
-  const slug = title
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .replace(/-{2,}/g, "-");
-
-  const safeTitle = slug.length > 0 ? slug : "amendment";
-  return `amendment-${amendmentId}-${safeTitle}-${Date.now().toString(36)}`;
-}
 
 function sanitizeText(input: unknown): string {
   if (typeof input !== "string") return "";
@@ -31,7 +23,9 @@ export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const status = searchParams.get("status");
   const validStatus =
-    status && Object.values(AmendmentStatus).includes(status as AmendmentStatus) ? (status as AmendmentStatus) : null;
+    status && Object.values(AmendmentStatus).includes(status as AmendmentStatus)
+      ? (status as AmendmentStatus)
+      : null;
 
   const where = validStatus ? { status: validStatus } : {};
   const amendments = await prisma.amendment.findMany({
@@ -88,6 +82,7 @@ export async function POST(request: NextRequest) {
   let body: {
     title?: unknown;
     description?: unknown;
+    originalContent?: unknown;
     proposedContent?: unknown;
     isSemanticChange?: unknown;
   };
@@ -99,16 +94,19 @@ export async function POST(request: NextRequest) {
 
   const title = sanitizeText(body.title);
   const description = sanitizeText(body.description);
+  const clientOriginalContent = sanitizeText(body.originalContent);
   const proposedContent = sanitizeText(body.proposedContent);
   const isSemanticChange =
     typeof body.isSemanticChange === "boolean" ? body.isSemanticChange : true;
 
   if (!title || !proposedContent) {
-    return new Response('"title", "proposedContent" are required', { status: 422 });
+    return new Response('"title", "proposedContent" are required', {
+      status: 422,
+    });
   }
 
   // Fetch current constitution for diff — graceful if GitHub is unavailable
-  let originalContent = "";
+  let originalContent = clientOriginalContent;
   try {
     const currentSnapshot = await fetchConstitutionSnapshot();
     originalContent = currentSnapshot.content;
@@ -131,9 +129,10 @@ export async function POST(request: NextRequest) {
   });
 
   // Attempt to create a GitHub PR — non-blocking
-  const branchName = buildBranchName(title, dbDraft.id);
+  const branchName = buildAmendmentBranchName(title, dbDraft.id);
   const amendmentAuthor = `Member #${actor.id}`;
-  const prBody = description || `${title}\n\nAmendment proposal by ${amendmentAuthor}.`;
+  const prBody =
+    description || `${title}\n\nAmendment proposal by ${amendmentAuthor}.`;
   try {
     const { prNumber, originalContent: prOriginal } = await createAmendmentPR({
       title,

--- a/next/app/api/amendments/route.ts
+++ b/next/app/api/amendments/route.ts
@@ -6,8 +6,6 @@ import {
   getActorFromRequest,
 } from "@/lib/services/amendmentService";
 import {
-  buildAmendmentBranchName,
-  createAmendmentPR,
   fetchConstitutionSnapshot,
 } from "@/lib/services/githubAmendmentService";
 
@@ -114,7 +112,7 @@ export async function POST(request: NextRequest) {
     // GitHub unavailable — continue without original content
   }
 
-  const dbDraft = await prisma.amendment.create({
+  const amendment = await prisma.amendment.create({
     data: {
       title,
       description,
@@ -126,36 +124,6 @@ export async function POST(request: NextRequest) {
       publishedAt: new Date(),
       primaryReviewOpenedAt: new Date(),
     },
-  });
-
-  // Attempt to create a GitHub PR — non-blocking
-  const branchName = buildAmendmentBranchName(title, dbDraft.id);
-  const amendmentAuthor = `Member #${actor.id}`;
-  const prBody =
-    description || `${title}\n\nAmendment proposal by ${amendmentAuthor}.`;
-  try {
-    const { prNumber, originalContent: prOriginal } = await createAmendmentPR({
-      title,
-      description: prBody,
-      proposedContent,
-      proposedBy: amendmentAuthor,
-      branchName,
-    });
-
-    await prisma.amendment.update({
-      where: { id: dbDraft.id },
-      data: {
-        githubBranch: branchName,
-        githubPrNumber: prNumber,
-        originalContent: prOriginal || originalContent,
-      },
-    });
-  } catch {
-    // GitHub PR creation failed — amendment still exists without a linked PR
-  }
-
-  const amendment = await prisma.amendment.findUnique({
-    where: { id: dbDraft.id },
     select: {
       id: true,
       title: true,

--- a/next/app/api/github/webhooks/amendment-maker/route.ts
+++ b/next/app/api/github/webhooks/amendment-maker/route.ts
@@ -1,0 +1,38 @@
+import crypto from "node:crypto";
+import { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+function timingSafeEqualHex(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left, "utf8");
+  const rightBuffer = Buffer.from(right, "utf8");
+
+  if (leftBuffer.length !== rightBuffer.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.text();
+  const webhookSecret = process.env.GITHUB_WEBHOOK_SECRET?.trim();
+
+  if (webhookSecret) {
+    const signature = request.headers.get("x-hub-signature-256");
+    if (!signature) {
+      return new Response("Missing GitHub webhook signature", { status: 401 });
+    }
+
+    const expectedSignature = `sha256=${crypto
+      .createHmac("sha256", webhookSecret)
+      .update(body)
+      .digest("hex")}`;
+
+    if (!timingSafeEqualHex(signature, expectedSignature)) {
+      return new Response("Invalid GitHub webhook signature", { status: 401 });
+    }
+  }
+
+  return new Response(null, { status: 204 });
+}

--- a/next/components/amendments/AmendmentCard.tsx
+++ b/next/components/amendments/AmendmentCard.tsx
@@ -32,7 +32,10 @@ export default function AmendmentCard({
   isAuthor = false,
   muted = false,
 }: AmendmentCardProps) {
-  const hasDiff = amendment.originalContent && amendment.proposedContent &&
+  const isNewAmendment = amendment.status === "PRIMARY_REVIEW";
+  const hasDiff =
+    amendment.originalContent &&
+    amendment.proposedContent &&
     amendment.originalContent !== amendment.proposedContent;
 
   return (
@@ -40,18 +43,28 @@ export default function AmendmentCard({
       href={`/about/constitution/amendments/${amendment.id}`}
       className={`block group ${muted ? "opacity-60 hover:opacity-80" : ""}`}
     >
-      <Card depth={2} className={`transition-colors hover:bg-surface-3/30 cursor-pointer ${muted ? "p-3" : "p-4 md:p-5"}`}>
+      <Card
+        depth={2}
+        className={`cursor-pointer transition-colors hover:bg-surface-3/30 ${muted ? "p-3" : "p-4 md:p-5"}`}
+      >
         <CardHeader className="p-0">
-          <div className="flex flex-wrap gap-2 items-center justify-between">
-            <div className="flex items-center gap-3 min-w-0 flex-1">
-              <CardTitle className={`group-hover:text-primary transition-colors leading-snug ${muted ? "text-sm" : "text-base sm:text-lg"}`}>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="min-w-0 flex-1">
+              <CardTitle
+                className={`group-hover:text-primary transition-colors leading-snug ${muted ? "text-sm" : "text-base sm:text-lg"}`}
+              >
                 {amendment.title}
               </CardTitle>
-              <span className="text-sm text-muted-foreground hidden sm:inline shrink-0">
+              <span className="mt-1 block text-xs text-muted-foreground sm:text-sm">
                 by {amendment.author?.name ?? "Unknown"}
               </span>
             </div>
-            <div className="flex items-center gap-1.5 shrink-0">
+            <div className="flex w-full flex-wrap items-center gap-1.5 sm:w-auto sm:justify-end">
+              {isNewAmendment && (
+                <span className="inline-flex items-center gap-1 rounded-md bg-amber-500/12 px-2 py-0.5 text-xs font-semibold text-amber-700 dark:text-amber-300">
+                  New
+                </span>
+              )}
               {isAuthor && (
                 <span className="inline-flex items-center gap-1 rounded-md bg-primary/10 px-2 py-0.5 text-xs font-semibold text-primary">
                   <Pen className="h-2.5 w-2.5" />
@@ -59,7 +72,7 @@ export default function AmendmentCard({
                 </span>
               )}
               <AmendmentStatusBadge status={amendment.status} />
-              <ChevronRight className="h-4 w-4 text-muted-foreground/40 group-hover:text-primary/60 transition-colors" />
+              <ChevronRight className="ml-auto h-4 w-4 text-muted-foreground/40 transition-colors group-hover:text-primary/60 sm:ml-0" />
             </div>
           </div>
         </CardHeader>

--- a/next/components/amendments/AmendmentDetailClient.tsx
+++ b/next/components/amendments/AmendmentDetailClient.tsx
@@ -88,13 +88,22 @@ type AmendmentPayload = {
   comments: CommentItem[];
 };
 
+function isNewAmendment(amendment: AmendmentPayload) {
+  return (
+    amendment.status === "PRIMARY_REVIEW" &&
+    amendment.primaryReviewClosedAt === null &&
+    amendment.votingOpenedAt === null
+  );
+}
+
 export default function AmendmentDetailClient({
   amendment: initialAmendment,
 }: {
   amendment: AmendmentPayload;
 }) {
   const router = useRouter();
-  const [amendment, setAmendment] = useState<AmendmentPayload>(initialAmendment);
+  const [amendment, setAmendment] =
+    useState<AmendmentPayload>(initialAmendment);
   const [isPrimary, setIsPrimary] = useState(false);
   const [isSeAdmin, setIsSeAdmin] = useState(false);
   const [isMember, setIsMember] = useState(false);
@@ -135,7 +144,10 @@ export default function AmendmentDetailClient({
     .filter((slot) => slot.holder?.id === userId)
     .map((slot) => slot.positionId);
 
-  async function changeStatus(nextStatus: AmendmentStatus, extraData?: Record<string, unknown>) {
+  async function changeStatus(
+    nextStatus: AmendmentStatus,
+    extraData?: Record<string, unknown>,
+  ) {
     setActionMessage("");
     try {
       const response = await fetch(`/api/amendments/${amendment.id}`, {
@@ -160,9 +172,13 @@ export default function AmendmentDetailClient({
           const full = await detailResponse.json();
           setAmendment((prev) => ({ ...prev, ...full }));
         }
-      } catch { /* ignore refresh failure */ }
+      } catch {
+        /* ignore refresh failure */
+      }
     } catch (err) {
-      setActionMessage(err instanceof Error ? err.message : "Failed to update status");
+      setActionMessage(
+        err instanceof Error ? err.message : "Failed to update status",
+      );
     }
   }
 
@@ -183,7 +199,39 @@ export default function AmendmentDetailClient({
       }));
       router.refresh();
     } catch (err) {
-      setActionMessage(err instanceof Error ? err.message : "Failed to merge amendment");
+      setActionMessage(
+        err instanceof Error ? err.message : "Failed to merge amendment",
+      );
+    }
+  }
+
+  async function resubmitPr() {
+    setActionMessage("");
+    try {
+      const response = await fetch(
+        `/api/amendments/${amendment.id}/resubmit-pr`,
+        {
+          method: "POST",
+        },
+      );
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || "Failed to re-submit PR");
+      }
+
+      const refreshed = await fetch(`/api/amendments/${amendment.id}`);
+      if (!refreshed.ok) {
+        throw new Error(
+          "PR was created, but the amendment could not be refreshed",
+        );
+      }
+
+      const full = await refreshed.json();
+      setAmendment((prev) => ({ ...prev, ...full }));
+    } catch (err) {
+      setActionMessage(
+        err instanceof Error ? err.message : "Failed to re-submit PR",
+      );
     }
   }
 
@@ -191,15 +239,36 @@ export default function AmendmentDetailClient({
     return <AmendmentDetailSkeleton />;
   }
 
+  const canResubmitPr =
+    !amendment.githubPrNumber &&
+    amendment.status !== "WITHDRAWN" &&
+    amendment.status !== "MERGED" &&
+    amendment.status !== "REJECTED" &&
+    (amendment.author.id === userId || isPrimary || isSeAdmin);
+
   return (
     <section className="w-full max-w-6xl mx-auto px-2 md:px-4 space-y-5">
       {/* Breadcrumb */}
       <AmendmentBreadcrumb items={[{ label: amendment.title }]} />
 
       <NeoCard depth={1} className="p-5 md:p-7 space-y-5">
+        {isNewAmendment(amendment) && (
+          <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="inline-flex items-center gap-1 rounded-md bg-amber-500/15 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-amber-800 dark:text-amber-200">
+                New Amendment
+              </span>
+              <p className="text-sm text-amber-900/80 dark:text-amber-100/90">
+                This proposal was just introduced and is currently in primary
+                officer review before member voting opens.
+              </p>
+            </div>
+          </div>
+        )}
+
         {/* Header — no inner card, just content within the NeoCard */}
         <div className="space-y-3">
-          <div className="flex flex-wrap gap-3 justify-between items-start">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
             <div className="space-y-1.5 min-w-0 flex-1">
               <h1 className="font-display text-2xl md:text-3xl font-bold leading-tight tracking-tight">
                 {amendment.title}
@@ -211,22 +280,41 @@ export default function AmendmentDetailClient({
                 </span>
               </p>
             </div>
-            <div className="flex flex-wrap gap-2 items-center shrink-0">
+            <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto sm:justify-end">
               <AmendmentStatusBadge status={amendment.status} />
-              {(isPrimary || isSeAdmin) && amendment.status !== "WITHDRAWN" && amendment.status !== "MERGED" && amendment.status !== "REJECTED" && (
-                <ConfirmationDialog
-                  trigger={
-                    <Button size="xs" variant="ghost" className="text-muted-foreground hover:text-destructive">
-                      Withdraw
-                    </Button>
-                  }
-                  title="Withdraw Amendment"
-                  description="This will withdraw the amendment from consideration."
-                  confirmLabel="Withdraw"
-                  variant="destructive"
-                  onConfirm={() => changeStatus("WITHDRAWN" as AmendmentStatus)}
-                />
+              {canResubmitPr && (
+                <Button
+                  size="xs"
+                  variant="outline"
+                  className="w-full sm:w-auto"
+                  onClick={resubmitPr}
+                >
+                  Re-submit PR
+                </Button>
               )}
+              {(isPrimary || isSeAdmin) &&
+                amendment.status !== "WITHDRAWN" &&
+                amendment.status !== "MERGED" &&
+                amendment.status !== "REJECTED" && (
+                  <ConfirmationDialog
+                    trigger={
+                      <Button
+                        size="xs"
+                        variant="ghost"
+                        className="w-full text-muted-foreground hover:text-destructive sm:w-auto"
+                      >
+                        Withdraw
+                      </Button>
+                    }
+                    title="Withdraw Amendment"
+                    description="This will withdraw the amendment from consideration."
+                    confirmLabel="Withdraw"
+                    variant="destructive"
+                    onConfirm={() =>
+                      changeStatus("WITHDRAWN" as AmendmentStatus)
+                    }
+                  />
+                )}
               {amendment.githubPrNumber && (
                 <TooltipProvider delayDuration={200}>
                   <Tooltip>
@@ -234,7 +322,7 @@ export default function AmendmentDetailClient({
                       <Link
                         href={`https://github.com/rit-sse/governing-docs/pull/${amendment.githubPrNumber}`}
                         target="_blank"
-                        className="inline-flex items-center gap-1.5 rounded-md bg-surface-3 px-2.5 py-1 text-xs font-mono font-medium text-foreground hover:bg-surface-4 transition-colors"
+                        className="inline-flex w-full items-center justify-center gap-1.5 rounded-md bg-surface-3 px-2.5 py-1 text-xs font-mono font-medium text-foreground transition-colors hover:bg-surface-4 sm:w-auto"
                       >
                         <svg
                           className="h-3.5 w-3.5 opacity-60"
@@ -270,8 +358,14 @@ export default function AmendmentDetailClient({
             events={[
               { label: "Created", date: amendment.createdAt },
               { label: "Published", date: amendment.publishedAt },
-              { label: "Primary review opened", date: amendment.primaryReviewOpenedAt },
-              { label: "Primary review closed", date: amendment.primaryReviewClosedAt },
+              {
+                label: "Primary review opened",
+                date: amendment.primaryReviewOpenedAt,
+              },
+              {
+                label: "Primary review closed",
+                date: amendment.primaryReviewClosedAt,
+              },
               { label: "Voting opened", date: amendment.votingOpenedAt },
               { label: "Voting closed", date: amendment.votingClosedAt },
             ]}
@@ -283,7 +377,11 @@ export default function AmendmentDetailClient({
               <Tooltip>
                 <TooltipTrigger asChild>
                   <span className="inline-flex items-center gap-1 text-xs font-medium text-amber-700 dark:text-amber-400 bg-amber-500/10 rounded-md px-2 py-0.5 w-fit cursor-help">
-                    <svg className="h-3 w-3" viewBox="0 0 20 20" fill="currentColor">
+                    <svg
+                      className="h-3 w-3"
+                      viewBox="0 0 20 20"
+                      fill="currentColor"
+                    >
                       <path
                         fillRule="evenodd"
                         d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z"
@@ -304,56 +402,61 @@ export default function AmendmentDetailClient({
           )}
         </div>
 
-      {/* Main content grid */}
-      <div className="grid gap-5 lg:grid-cols-5">
-        {/* Diff viewer — takes majority of space */}
-        <Card depth={2} className="lg:col-span-3 p-4 md:p-5 order-2 lg:order-1">
-          <CardHeader className="p-0 pb-3 flex flex-row items-center justify-between">
-            <CardTitle>Patch Review</CardTitle>
-            <span className="text-xs text-muted-foreground font-mono">
-              inline diff
-            </span>
-          </CardHeader>
-          <CardContent className="p-0">
-            <DiffViewer
-              originalContent={amendment.originalContent}
-              proposedContent={amendment.proposedContent}
+        {/* Main content grid */}
+        <div className="grid gap-5 lg:grid-cols-5">
+          {/* Diff viewer — takes majority of space */}
+          <Card
+            depth={2}
+            className="lg:col-span-3 p-4 md:p-5 order-2 lg:order-1"
+          >
+            <CardHeader className="p-0 pb-3 flex flex-row items-center justify-between">
+              <CardTitle>Patch Review</CardTitle>
+              <span className="text-xs text-muted-foreground font-mono">
+                inline diff
+              </span>
+            </CardHeader>
+            <CardContent className="p-0">
+              <DiffViewer
+                originalContent={amendment.originalContent}
+                proposedContent={amendment.proposedContent}
+              />
+            </CardContent>
+          </Card>
+
+          {/* Right sidebar — VotePanel appears first on mobile */}
+          <div className="lg:col-span-2 space-y-5 order-1 lg:order-2">
+            <VotePanel
+              amendmentId={amendment.id}
+              isSemanticChange={amendment.isSemanticChange}
+              status={amendment.status}
+              totalVotes={amendment.votes.totalVotes}
+              approveVotes={amendment.votes.approveVotes}
+              rejectVotes={amendment.votes.rejectVotes}
+              requiredVotingParticipation={
+                amendment.votes.requiredVotingParticipation
+              }
+              totalActiveMembers={amendment.votes.totalActiveMembers}
+              userVote={amendment.userVote}
+              isMember={isMember}
+              isUser={isUser}
+              isPrimary={isPrimary}
+              isSeAdmin={isSeAdmin}
+              primaryReview={amendment.primaryReview}
+              votingEndsAt={amendment.votingEndsAt}
+              userPrimaryPositionIds={userPrimaryPositionIds}
+              onChangeStatus={changeStatus}
+              onMerge={merge}
+              actionMessage={actionMessage}
             />
-          </CardContent>
-        </Card>
 
-        {/* Right sidebar — VotePanel appears first on mobile */}
-        <div className="lg:col-span-2 space-y-5 order-1 lg:order-2">
-          <VotePanel
-            amendmentId={amendment.id}
-            isSemanticChange={amendment.isSemanticChange}
-            status={amendment.status}
-            totalVotes={amendment.votes.totalVotes}
-            approveVotes={amendment.votes.approveVotes}
-            rejectVotes={amendment.votes.rejectVotes}
-            requiredVotingParticipation={amendment.votes.requiredVotingParticipation}
-            totalActiveMembers={amendment.votes.totalActiveMembers}
-            userVote={amendment.userVote}
-            isMember={isMember}
-            isUser={isUser}
-            isPrimary={isPrimary}
-            isSeAdmin={isSeAdmin}
-            primaryReview={amendment.primaryReview}
-            votingEndsAt={amendment.votingEndsAt}
-            userPrimaryPositionIds={userPrimaryPositionIds}
-            onChangeStatus={changeStatus}
-            onMerge={merge}
-            actionMessage={actionMessage}
-          />
-
-          <CommentThread
-            amendmentId={amendment.id}
-            initialComments={amendment.comments}
-            canComment={isMember}
-            isUser={isUser}
-          />
+            <CommentThread
+              amendmentId={amendment.id}
+              initialComments={amendment.comments}
+              canComment={isMember}
+              isUser={isUser}
+            />
+          </div>
         </div>
-      </div>
       </NeoCard>
     </section>
   );

--- a/next/components/amendments/AmendmentDetailClient.tsx
+++ b/next/components/amendments/AmendmentDetailClient.tsx
@@ -19,6 +19,8 @@ import AmendmentBreadcrumb from "@/components/amendments/AmendmentBreadcrumb";
 import AmendmentTimeline from "@/components/amendments/AmendmentTimeline";
 import ConfirmationDialog from "@/components/amendments/ConfirmationDialog";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import AmendmentDetailSkeleton from "@/components/amendments/AmendmentDetailSkeleton";
 import { AmendmentStatus } from "@prisma/client";
 
@@ -110,8 +112,18 @@ export default function AmendmentDetailClient({
   const [isUser, setIsUser] = useState(false);
   const [roleName, setRoleName] = useState("");
   const [actionMessage, setActionMessage] = useState("");
+  const [editMessage, setEditMessage] = useState("");
   const [userId, setUserId] = useState<number | null>(null);
   const [authLoaded, setAuthLoaded] = useState(false);
+  const [isEditingDraft, setIsEditingDraft] = useState(false);
+  const [draftTitle, setDraftTitle] = useState(initialAmendment.title);
+  const [draftDescription, setDraftDescription] = useState(
+    initialAmendment.description,
+  );
+  const [draftProposedContent, setDraftProposedContent] = useState(
+    initialAmendment.proposedContent,
+  );
+  const [isSavingDraft, setIsSavingDraft] = useState(false);
 
   useEffect(() => {
     (async () => {
@@ -160,6 +172,9 @@ export default function AmendmentDetailClient({
         throw new Error(message || "Failed to update status");
       }
       const updated = await response.json();
+      if (updated?.prCreationWarning) {
+        setActionMessage(updated.prCreationWarning);
+      }
       setAmendment((prev) => ({
         ...prev,
         status: updated.status as AmendmentStatus,
@@ -205,7 +220,7 @@ export default function AmendmentDetailClient({
     }
   }
 
-  async function resubmitPr() {
+  async function createPr() {
     setActionMessage("");
     try {
       const response = await fetch(
@@ -216,7 +231,7 @@ export default function AmendmentDetailClient({
       );
       if (!response.ok) {
         const message = await response.text();
-        throw new Error(message || "Failed to re-submit PR");
+        throw new Error(message || "Failed to create PR");
       }
 
       const refreshed = await fetch(`/api/amendments/${amendment.id}`);
@@ -230,8 +245,57 @@ export default function AmendmentDetailClient({
       setAmendment((prev) => ({ ...prev, ...full }));
     } catch (err) {
       setActionMessage(
-        err instanceof Error ? err.message : "Failed to re-submit PR",
+        err instanceof Error ? err.message : "Failed to create PR",
       );
+    }
+  }
+
+  async function saveDraftEdits() {
+    setEditMessage("");
+
+    if (!draftTitle.trim()) {
+      setEditMessage("Title is required");
+      return;
+    }
+
+    if (!draftProposedContent.trim()) {
+      setEditMessage("Proposed text is required");
+      return;
+    }
+
+    setIsSavingDraft(true);
+    try {
+      const response = await fetch(`/api/amendments/${amendment.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: draftTitle,
+          description: draftDescription,
+          proposedContent: draftProposedContent,
+        }),
+      });
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || "Failed to save amendment edits");
+      }
+
+      const refreshed = await fetch(`/api/amendments/${amendment.id}`);
+      if (!refreshed.ok) {
+        throw new Error("Edits were saved, but the amendment could not be refreshed");
+      }
+
+      const full = await refreshed.json();
+      setAmendment((prev) => ({ ...prev, ...full }));
+      setDraftTitle(full.title);
+      setDraftDescription(full.description);
+      setDraftProposedContent(full.proposedContent);
+      setIsEditingDraft(false);
+    } catch (err) {
+      setEditMessage(
+        err instanceof Error ? err.message : "Failed to save amendment edits",
+      );
+    } finally {
+      setIsSavingDraft(false);
     }
   }
 
@@ -239,11 +303,13 @@ export default function AmendmentDetailClient({
     return <AmendmentDetailSkeleton />;
   }
 
-  const canResubmitPr =
+  const canEditDraft =
+    amendment.status === "PRIMARY_REVIEW" &&
+    (amendment.author.id === userId || isPrimary || isSeAdmin);
+
+  const canCreatePr =
     !amendment.githubPrNumber &&
-    amendment.status !== "WITHDRAWN" &&
-    amendment.status !== "MERGED" &&
-    amendment.status !== "REJECTED" &&
+    (amendment.status === "VOTING" || amendment.status === "APPROVED") &&
     (amendment.author.id === userId || isPrimary || isSeAdmin);
 
   return (
@@ -282,14 +348,30 @@ export default function AmendmentDetailClient({
             </div>
             <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto sm:justify-end">
               <AmendmentStatusBadge status={amendment.status} />
-              {canResubmitPr && (
+              {canEditDraft && (
                 <Button
                   size="xs"
                   variant="outline"
                   className="w-full sm:w-auto"
-                  onClick={resubmitPr}
+                  onClick={() => {
+                    setEditMessage("");
+                    setDraftTitle(amendment.title);
+                    setDraftDescription(amendment.description);
+                    setDraftProposedContent(amendment.proposedContent);
+                    setIsEditingDraft((prev) => !prev);
+                  }}
                 >
-                  Re-submit PR
+                  {isEditingDraft ? "Close Editor" : "Edit Draft Text"}
+                </Button>
+              )}
+              {canCreatePr && (
+                <Button
+                  size="xs"
+                  variant="outline"
+                  className="w-full sm:w-auto"
+                  onClick={createPr}
+                >
+                  Create PR
                 </Button>
               )}
               {(isPrimary || isSeAdmin) &&
@@ -401,6 +483,93 @@ export default function AmendmentDetailClient({
             </TooltipProvider>
           )}
         </div>
+
+        {isEditingDraft && canEditDraft && (
+          <Card depth={2} className="p-4 md:p-5 space-y-4">
+            <CardHeader className="p-0">
+              <CardTitle>Edit Quorum Draft</CardTitle>
+            </CardHeader>
+            <CardContent className="p-0 space-y-4">
+              <div className="space-y-2">
+                <label
+                  htmlFor="amendment-edit-title"
+                  className="text-sm font-medium"
+                >
+                  Title
+                </label>
+                <Input
+                  id="amendment-edit-title"
+                  value={draftTitle}
+                  onChange={(event) => setDraftTitle(event.target.value)}
+                  disabled={isSavingDraft}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label
+                  htmlFor="amendment-edit-description"
+                  className="text-sm font-medium"
+                >
+                  Description
+                </label>
+                <Textarea
+                  id="amendment-edit-description"
+                  value={draftDescription}
+                  onChange={(event) => setDraftDescription(event.target.value)}
+                  rows={3}
+                  disabled={isSavingDraft}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label
+                  htmlFor="amendment-edit-content"
+                  className="text-sm font-medium"
+                >
+                  Proposed Constitution Text
+                </label>
+                <Textarea
+                  id="amendment-edit-content"
+                  value={draftProposedContent}
+                  onChange={(event) =>
+                    setDraftProposedContent(event.target.value)
+                  }
+                  rows={16}
+                  className="font-mono text-sm"
+                  disabled={isSavingDraft}
+                />
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  size="sm"
+                  onClick={saveDraftEdits}
+                  disabled={isSavingDraft}
+                >
+                  {isSavingDraft ? "Saving..." : "Save Draft"}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => {
+                    setEditMessage("");
+                    setDraftTitle(amendment.title);
+                    setDraftDescription(amendment.description);
+                    setDraftProposedContent(amendment.proposedContent);
+                    setIsEditingDraft(false);
+                  }}
+                  disabled={isSavingDraft}
+                >
+                  Cancel
+                </Button>
+              </div>
+
+              {editMessage && (
+                <p className="text-sm text-destructive">{editMessage}</p>
+              )}
+            </CardContent>
+          </Card>
+        )}
 
         {/* Main content grid */}
         <div className="grid gap-5 lg:grid-cols-5">

--- a/next/components/amendments/AmendmentWizard.tsx
+++ b/next/components/amendments/AmendmentWizard.tsx
@@ -19,7 +19,9 @@ type AmendmentWizardProps = {
   initialContent: string;
 };
 
-export default function AmendmentWizard({ initialContent }: AmendmentWizardProps) {
+export default function AmendmentWizard({
+  initialContent,
+}: AmendmentWizardProps) {
   const router = useRouter();
   const [step, setStep] = useState(0);
   const [proposedContent, setProposedContent] = useState(initialContent);
@@ -49,6 +51,7 @@ export default function AmendmentWizard({ initialContent }: AmendmentWizardProps
           title: title.trim(),
           description: description.trim(),
           isSemanticChange,
+          originalContent: initialContent,
           proposedContent,
         }),
       });
@@ -65,7 +68,8 @@ export default function AmendmentWizard({ initialContent }: AmendmentWizardProps
       }
       router.push(`/about/constitution/amendments/${amendmentId}`);
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to submit amendment";
+      const message =
+        err instanceof Error ? err.message : "Failed to submit amendment";
       setError(message);
       setLoading(false);
     }

--- a/next/components/amendments/VotePanel.tsx
+++ b/next/components/amendments/VotePanel.tsx
@@ -19,7 +19,15 @@ import { AmendmentStatus } from "@prisma/client";
 type VotePanelProps = {
   amendmentId: number;
   isSemanticChange: boolean;
-  status: "DRAFT" | "OPEN" | "PRIMARY_REVIEW" | "VOTING" | "APPROVED" | "REJECTED" | "MERGED" | "WITHDRAWN";
+  status:
+    | "DRAFT"
+    | "OPEN"
+    | "PRIMARY_REVIEW"
+    | "VOTING"
+    | "APPROVED"
+    | "REJECTED"
+    | "MERGED"
+    | "WITHDRAWN";
   totalVotes: number;
   approveVotes: number;
   rejectVotes: number;
@@ -53,7 +61,10 @@ type VotePanelProps = {
   /** The position IDs held by the current user (for per-position voting) */
   userPrimaryPositionIds?: number[];
   /** Admin action callbacks */
-  onChangeStatus?: (s: AmendmentStatus, extraData?: Record<string, unknown>) => void;
+  onChangeStatus?: (
+    s: AmendmentStatus,
+    extraData?: Record<string, unknown>,
+  ) => void;
   onMerge?: () => void;
   actionMessage?: string;
 };
@@ -122,7 +133,8 @@ function canPassAmendment({
   totalActiveMembers: number;
 }) {
   const hasQuorum = totalVotes >= requiredVotingParticipation;
-  const hasSuperMajority = totalVotes > 0 && approveVotes >= Math.ceil((2 / 3) * totalVotes);
+  const hasSuperMajority =
+    totalVotes > 0 && approveVotes >= Math.ceil((2 / 3) * totalVotes);
 
   if (!isSemanticChange) {
     return {
@@ -160,7 +172,8 @@ function ThresholdBar({
   met: boolean;
   colorVar: string;
 }) {
-  const pct = required > 0 ? Math.min(100, Math.round((current / required) * 100)) : 100;
+  const pct =
+    required > 0 ? Math.min(100, Math.round((current / required) * 100)) : 100;
 
   return (
     <TooltipProvider delayDuration={150}>
@@ -183,7 +196,10 @@ function ThresholdBar({
             <div className="h-2 rounded-full bg-surface-3 overflow-hidden">
               <div
                 className="h-full rounded-full transition-all duration-500 ease-out"
-                style={{ width: `${pct}%`, backgroundColor: `hsl(var(${colorVar}))` }}
+                style={{
+                  width: `${pct}%`,
+                  backgroundColor: `hsl(var(${colorVar}))`,
+                }}
               />
             </div>
           </div>
@@ -210,7 +226,9 @@ function VoteLegendItem({
   tooltip?: string;
 }) {
   const inner = (
-    <div className={`flex items-center gap-2 text-sm ${tooltip ? "cursor-help" : ""}`}>
+    <div
+      className={`flex items-center gap-2 text-sm ${tooltip ? "cursor-help" : ""}`}
+    >
       <span
         className="inline-block h-3 w-3 rounded-sm shrink-0"
         style={{ backgroundColor: `hsl(var(${cssVar}))` }}
@@ -273,7 +291,17 @@ export default function VotePanel({
   });
   const [localPrimaryReview, setLocalPrimaryReview] = useState(primaryReview);
 
-  const votingWindowEnded = votingEndsAt ? new Date(votingEndsAt).getTime() < Date.now() : false;
+  const votingWindowEnded = votingEndsAt
+    ? new Date(votingEndsAt).getTime() < Date.now()
+    : false;
+  const currentVotingWindowHours = votingEndsAt
+    ? Math.max(
+        1,
+        Math.ceil(
+          (new Date(votingEndsAt).getTime() - Date.now()) / (1000 * 60 * 60),
+        ),
+      )
+    : null;
   const canVote = status === "VOTING" && !votingWindowEnded;
   const notVoted = Math.max(0, totalActiveMembers - localTotals.totalVotes);
   const totalForPct = localTotals.totalVotes || 1;
@@ -392,7 +420,9 @@ export default function VotePanel({
           {/* Position key slots */}
           <div className="space-y-2">
             {localPrimaryReview.positionSlots.map((slot) => {
-              const isMyPosition = userPrimaryPositionIds.includes(slot.positionId);
+              const isMyPosition = userPrimaryPositionIds.includes(
+                slot.positionId,
+              );
               const canActOnSlot = isMyPosition && !slot.voted;
               const hasVoted = slot.voted;
 
@@ -431,11 +461,13 @@ export default function VotePanel({
                       <p className="text-xs text-muted-foreground truncate">
                         {slot.holder?.name ?? "Vacant"}
                         {hasVoted && (
-                          <span className={`ml-1.5 font-medium ${
-                            slot.approve
-                              ? "text-emerald-600 dark:text-emerald-400"
-                              : "text-rose-600 dark:text-rose-400"
-                          }`}>
+                          <span
+                            className={`ml-1.5 font-medium ${
+                              slot.approve
+                                ? "text-emerald-600 dark:text-emerald-400"
+                                : "text-rose-600 dark:text-rose-400"
+                            }`}
+                          >
                             — {slot.approve ? "Approved" : "Rejected"}
                           </span>
                         )}
@@ -446,11 +478,13 @@ export default function VotePanel({
                     {isMyPosition && (
                       <div className="flex gap-1.5 shrink-0">
                         {hasVoted ? (
-                          <span className={`text-xs font-semibold px-2 py-1 rounded ${
-                            slot.approve
-                              ? "text-emerald-700 dark:text-emerald-300"
-                              : "text-rose-700 dark:text-rose-300"
-                          }`}>
+                          <span
+                            className={`text-xs font-semibold px-2 py-1 rounded ${
+                              slot.approve
+                                ? "text-emerald-700 dark:text-emerald-300"
+                                : "text-rose-700 dark:text-rose-300"
+                            }`}
+                          >
                             {slot.approve ? "Approved" : "Rejected"}
                           </span>
                         ) : (
@@ -460,7 +494,9 @@ export default function VotePanel({
                               variant="outline"
                               disabled={submitting}
                               className="text-emerald-700 dark:text-emerald-300 border-emerald-500/30 hover:bg-emerald-500/10 h-7 px-2"
-                              onClick={() => castPositionVote(slot.positionId, true)}
+                              onClick={() =>
+                                castPositionVote(slot.positionId, true)
+                              }
                             >
                               Approve
                             </Button>
@@ -469,7 +505,9 @@ export default function VotePanel({
                               variant="outline"
                               disabled={submitting}
                               className="text-rose-700 dark:text-rose-300 border-rose-500/30 hover:bg-rose-500/10 h-7 px-2"
-                              onClick={() => castPositionVote(slot.positionId, false)}
+                              onClick={() =>
+                                castPositionVote(slot.positionId, false)
+                              }
                             >
                               Reject
                             </Button>
@@ -505,10 +543,14 @@ export default function VotePanel({
               rejected
             </span>
             <span className="ml-auto">
-              <span className="tabular-nums">{localPrimaryReview.votedCount}</span>
+              <span className="tabular-nums">
+                {localPrimaryReview.votedCount}
+              </span>
               {" / "}
-              <span className="tabular-nums">{localPrimaryReview.totalPositions}</span>
-              {" "}voted
+              <span className="tabular-nums">
+                {localPrimaryReview.totalPositions}
+              </span>{" "}
+              voted
             </span>
           </div>
         </div>
@@ -517,28 +559,34 @@ export default function VotePanel({
       {/* Non-semantic info banner */}
       {status !== "PRIMARY_REVIEW" && !isSemanticChange && canVote && (
         <div className="rounded-lg bg-sky-500/8 border border-sky-500/20 px-3 py-2 text-xs text-sky-700 dark:text-sky-300">
-          Non-semantic changes require primary officer consensus. Only primary officers vote on this type.
+          Non-semantic changes require primary officer consensus. Only primary
+          officers vote on this type.
         </div>
       )}
 
       {/* Voting countdown */}
-      {canVote && votingEndsAt && (() => {
-        const remaining = new Date(votingEndsAt).getTime() - Date.now();
-        if (remaining <= 0) {
+      {canVote &&
+        votingEndsAt &&
+        (() => {
+          const remaining = new Date(votingEndsAt).getTime() - Date.now();
+          if (remaining <= 0) {
+            return (
+              <div className="rounded-lg bg-rose-500/10 border border-rose-500/20 px-3 py-2 text-xs text-rose-700 dark:text-rose-300 font-medium">
+                Voting window has ended
+              </div>
+            );
+          }
+          const days = Math.floor(remaining / (1000 * 60 * 60 * 24));
+          const hours = Math.floor(
+            (remaining % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60),
+          );
           return (
-            <div className="rounded-lg bg-rose-500/10 border border-rose-500/20 px-3 py-2 text-xs text-rose-700 dark:text-rose-300 font-medium">
-              Voting window has ended
+            <div className="rounded-lg bg-amber-500/10 border border-amber-500/20 px-3 py-2 text-xs text-amber-700 dark:text-amber-300 font-medium">
+              {days > 0 ? `${days} day${days !== 1 ? "s" : ""}, ` : ""}
+              {hours} hour{hours !== 1 ? "s" : ""} remaining
             </div>
           );
-        }
-        const days = Math.floor(remaining / (1000 * 60 * 60 * 24));
-        const hours = Math.floor((remaining % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
-        return (
-          <div className="rounded-lg bg-amber-500/10 border border-amber-500/20 px-3 py-2 text-xs text-amber-700 dark:text-amber-300 font-medium">
-            {days > 0 ? `${days} day${days !== 1 ? "s" : ""}, ` : ""}{hours} hour{hours !== 1 ? "s" : ""} remaining
-          </div>
-        );
-      })()}
+        })()}
 
       {/* Pie chart + legend */}
       {status !== "PRIMARY_REVIEW" && (
@@ -629,7 +677,11 @@ export default function VotePanel({
                       </Button>
                     </TooltipTrigger>
                     <TooltipContent>
-                      <p>{localUserVote === true ? "You approved this amendment. Click to re-confirm." : "Vote to approve this amendment"}</p>
+                      <p>
+                        {localUserVote === true
+                          ? "You approved this amendment. Click to re-confirm."
+                          : "Vote to approve this amendment"}
+                      </p>
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
@@ -638,14 +690,20 @@ export default function VotePanel({
                     <TooltipTrigger asChild>
                       <Button
                         disabled={submitting}
-                        variant={localUserVote === false ? "destructive" : "outline"}
+                        variant={
+                          localUserVote === false ? "destructive" : "outline"
+                        }
                         onClick={() => castVote(false)}
                       >
                         {localUserVote === false ? "Rejected" : "Reject"}
                       </Button>
                     </TooltipTrigger>
                     <TooltipContent>
-                      <p>{localUserVote === false ? "You rejected this amendment. Click to re-confirm." : "Vote to reject this amendment"}</p>
+                      <p>
+                        {localUserVote === false
+                          ? "You rejected this amendment. Click to re-confirm."
+                          : "Vote to reject this amendment"}
+                      </p>
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
@@ -691,7 +749,9 @@ export default function VotePanel({
       )}
 
       {/* Outcome badge for closed votes */}
-      {(status === "APPROVED" || status === "REJECTED" || status === "MERGED") && (
+      {(status === "APPROVED" ||
+        status === "REJECTED" ||
+        status === "MERGED") && (
         <div
           className={`rounded-lg px-4 py-3 text-sm font-medium ${
             status === "REJECTED"
@@ -716,48 +776,92 @@ export default function VotePanel({
               {localPrimaryReview.majorityApproves && (
                 <VotingDurationDialog
                   trigger={
-                    <Button size="sm" className="w-full">Open Member Voting</Button>
+                    <Button size="sm" className="w-full">
+                      Open Member Voting
+                    </Button>
                   }
-                  onConfirm={(hours) => onChangeStatus("VOTING" as AmendmentStatus, { votingDurationHours: hours })}
+                  onConfirm={(hours) =>
+                    onChangeStatus("VOTING" as AmendmentStatus, {
+                      votingDurationHours: hours,
+                    })
+                  }
                 />
               )}
               {localPrimaryReview.majorityRejects && (
                 <ConfirmationDialog
                   trigger={
-                    <Button size="sm" variant="destructive" className="w-full">Close as Rejected</Button>
+                    <Button size="sm" variant="destructive" className="w-full">
+                      Close as Rejected
+                    </Button>
                   }
                   title="Reject Amendment"
                   description="Primary officers have rejected this amendment."
                   confirmLabel="Reject"
                   variant="destructive"
-                  onConfirm={() => onChangeStatus("REJECTED" as AmendmentStatus)}
+                  onConfirm={() =>
+                    onChangeStatus("REJECTED" as AmendmentStatus)
+                  }
                 />
               )}
             </div>
           )}
 
-          {/* VOTING: approve or reject (after window ends) */}
-          {status === "VOTING" && isPrimary && votingWindowEnded && (
-            <div className="flex gap-2 pt-1 border-t border-border/40">
-              <ConfirmationDialog
+          {/* VOTING: edit the window, then approve or reject once it closes */}
+          {status === "VOTING" && isPrimary && (
+            <div className="space-y-2 pt-1 border-t border-border/40">
+              <VotingDurationDialog
                 trigger={
-                  <Button size="sm" className="flex-1">Approve</Button>
+                  <Button size="sm" variant="outline" className="w-full">
+                    Edit Voting Window
+                  </Button>
                 }
-                title="Approve Amendment"
-                description="This will approve the amendment and close voting."
-                confirmLabel="Approve"
-                onConfirm={() => onChangeStatus("APPROVED" as AmendmentStatus)}
-              />
-              <ConfirmationDialog
-                trigger={
-                  <Button size="sm" variant="destructive" className="flex-1">Reject</Button>
+                title="Edit Voting Window"
+                description="Update how much longer member voting should remain open. The new duration is applied from now."
+                confirmLabel="Save Voting Window"
+                defaultHours={currentVotingWindowHours}
+                onConfirm={(hours) =>
+                  onChangeStatus("VOTING" as AmendmentStatus, {
+                    votingDurationHours: hours,
+                    resetVotingWindowFromNow: true,
+                  })
                 }
-                title="Reject Amendment"
-                description="This will reject the amendment."
-                confirmLabel="Reject"
-                variant="destructive"
-                onConfirm={() => onChangeStatus("REJECTED" as AmendmentStatus)}
               />
+
+              {votingWindowEnded && (
+                <div className="flex gap-2">
+                  <ConfirmationDialog
+                    trigger={
+                      <Button size="sm" className="flex-1">
+                        Approve
+                      </Button>
+                    }
+                    title="Approve Amendment"
+                    description="This will approve the amendment and close voting."
+                    confirmLabel="Approve"
+                    onConfirm={() =>
+                      onChangeStatus("APPROVED" as AmendmentStatus)
+                    }
+                  />
+                  <ConfirmationDialog
+                    trigger={
+                      <Button
+                        size="sm"
+                        variant="destructive"
+                        className="flex-1"
+                      >
+                        Reject
+                      </Button>
+                    }
+                    title="Reject Amendment"
+                    description="This will reject the amendment."
+                    confirmLabel="Reject"
+                    variant="destructive"
+                    onConfirm={() =>
+                      onChangeStatus("REJECTED" as AmendmentStatus)
+                    }
+                  />
+                </div>
+              )}
             </div>
           )}
 
@@ -766,7 +870,9 @@ export default function VotePanel({
             <div className="pt-1 border-t border-border/40">
               <ConfirmationDialog
                 trigger={
-                  <Button size="sm" className="w-full">Merge into Constitution</Button>
+                  <Button size="sm" className="w-full">
+                    Merge into Constitution
+                  </Button>
                 }
                 title="Merge Pull Request"
                 description="This will merge the amendment into the governing documents."

--- a/next/components/amendments/VotingDurationDialog.tsx
+++ b/next/components/amendments/VotingDurationDialog.tsx
@@ -18,6 +18,10 @@ import { Clock } from "lucide-react";
 type VotingDurationDialogProps = {
   trigger: React.ReactNode;
   onConfirm: (durationHours: number) => void | Promise<void>;
+  title?: string;
+  description?: string;
+  confirmLabel?: string;
+  defaultHours?: number | null;
 };
 
 const PRESETS = [
@@ -30,17 +34,38 @@ const PRESETS = [
 export default function VotingDurationDialog({
   trigger,
   onConfirm,
+  title = "Open Member Voting",
+  description = "Primary officers have approved this amendment. Choose how long the voting window should be open. Voting starts immediately.",
+  confirmLabel = "Start Voting Now",
+  defaultHours = 168,
 }: VotingDurationDialogProps) {
   const [open, setOpen] = useState(false);
-  const [selectedPreset, setSelectedPreset] = useState<number | null>(168);
-  const [useCustom, setUseCustom] = useState(false);
-  const [days, setDays] = useState("");
-  const [hours, setHours] = useState("");
+  const normalizedDefaultHours = defaultHours ?? 168;
+  const defaultPreset = PRESETS.some(
+    (preset) => preset.hours === normalizedDefaultHours,
+  )
+    ? normalizedDefaultHours
+    : 168;
+  const [selectedPreset, setSelectedPreset] = useState<number | null>(
+    defaultPreset,
+  );
+  const [useCustom, setUseCustom] = useState(
+    defaultHours !== null &&
+      !PRESETS.some((preset) => preset.hours === normalizedDefaultHours),
+  );
+  const [days, setDays] = useState(
+    useCustom ? String(Math.floor(normalizedDefaultHours / 24)) : "",
+  );
+  const [hours, setHours] = useState(
+    useCustom ? String(Math.floor(normalizedDefaultHours % 24)) : "",
+  );
   const [minutes, setMinutes] = useState("");
   const [loading, setLoading] = useState(false);
 
   const customTotalHours =
-    (parseInt(days) || 0) * 24 + (parseInt(hours) || 0) + (parseInt(minutes) || 0) / 60;
+    (parseInt(days) || 0) * 24 +
+    (parseInt(hours) || 0) +
+    (parseInt(minutes) || 0) / 60;
   const effectiveHours = useCustom ? customTotalHours : (selectedPreset ?? 0);
   const isValid = effectiveHours >= 0.5 && effectiveHours <= 336;
 
@@ -75,12 +100,9 @@ export default function VotingDurationDialog({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Clock className="h-5 w-5 text-primary/60" />
-            Open Member Voting
+            {title}
           </DialogTitle>
-          <DialogDescription>
-            Primary officers have approved this amendment. Choose how long the
-            voting window should be open. Voting starts immediately.
-          </DialogDescription>
+          <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4 py-2">
@@ -116,10 +138,14 @@ export default function VotingDurationDialog({
               type="button"
               onClick={() => setUseCustom(!useCustom)}
               className={`text-sm font-medium transition-colors ${
-                useCustom ? "text-primary" : "text-muted-foreground hover:text-foreground"
+                useCustom
+                  ? "text-primary"
+                  : "text-muted-foreground hover:text-foreground"
               }`}
             >
-              {useCustom ? "Using custom duration" : "Or set a custom duration..."}
+              {useCustom
+                ? "Using custom duration"
+                : "Or set a custom duration..."}
             </button>
             {useCustom && (
               <div className="flex items-center gap-2">
@@ -169,18 +195,22 @@ export default function VotingDurationDialog({
               Voting will be open for{" "}
               <span className="font-semibold text-foreground">
                 {formatDuration(effectiveHours)}
-              </span>
-              {" "}and starts immediately upon confirmation.
+              </span>{" "}
+              and starts immediately upon confirmation.
             </div>
           )}
         </div>
 
         <DialogFooter>
-          <Button variant="neutral" onClick={() => setOpen(false)} disabled={loading}>
+          <Button
+            variant="neutral"
+            onClick={() => setOpen(false)}
+            disabled={loading}
+          >
             Cancel
           </Button>
           <Button onClick={handleConfirm} disabled={loading || !isValid}>
-            {loading ? "Starting vote..." : "Start Voting Now"}
+            {loading ? "Saving..." : confirmLabel}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/next/lib/services/githubAmendmentService.ts
+++ b/next/lib/services/githubAmendmentService.ts
@@ -1,8 +1,12 @@
+import jwt from "jsonwebtoken";
+
 const GOVERNING_DOC_OWNER = "rit-sse";
 const GOVERNING_DOC_REPO = "governing-docs";
 const GOVERNING_DOC_BRANCH = "main";
 const GOVERNING_DOC_PATH = "constitution.md";
 const GOVERNING_DOCS_API = `https://api.github.com/repos/${GOVERNING_DOC_OWNER}/${GOVERNING_DOC_REPO}`;
+const GITHUB_API_VERSION = "2022-11-28";
+const GITHUB_INSTALLATION_TOKEN_BUFFER_MS = 60_000;
 
 type GitHubFileResponse = {
   content: string;
@@ -24,6 +28,15 @@ type GitHubPullRequest = {
   mergeable: boolean | null;
 };
 
+type GitHubInstallation = {
+  id: number;
+};
+
+type GitHubInstallationToken = {
+  token: string;
+  expires_at: string;
+};
+
 export type ConstitutionFileSnapshot = {
   content: string;
   sha: string;
@@ -36,18 +49,206 @@ export type AmendmentPRResult = {
   originalContent: string;
 };
 
-function getGithubToken(): string {
-  const token = process.env.GITHUB_PAT;
+export function buildAmendmentBranchName(
+  title: string,
+  amendmentId: number,
+): string {
+  const slug = title
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+
+  const safeTitle = slug.length > 0 ? slug : "amendment";
+  return `amendment-${amendmentId}-${safeTitle}-${Date.now().toString(36)}`;
+}
+
+function normalizeGithubPrivateKey(privateKey: string): string {
+  return privateKey.replace(/\\n/g, "\n").trim();
+}
+
+function getLegacyGithubToken(): string | null {
+  const token = process.env.GITHUB_PAT?.trim();
+  return token && token.length > 0 ? token : null;
+}
+
+function getGithubAppConfig():
+  | {
+      appId: string;
+      installationId: number | null;
+      privateKey: string;
+    }
+  | null {
+  const appId = process.env.GITHUB_APP_ID?.trim();
+  const privateKey = process.env.GITHUB_APP_PRIVATE_KEY?.trim();
+
+  if (!appId || !privateKey) {
+    return null;
+  }
+
+  const installationIdValue = process.env.GITHUB_APP_INSTALLATION_ID?.trim();
+  const installationId = installationIdValue ? Number(installationIdValue) : null;
+
+  if (installationIdValue && Number.isNaN(installationId)) {
+    throw new Error("GITHUB_APP_INSTALLATION_ID must be a number when provided.");
+  }
+
+  return {
+    appId,
+    installationId,
+    privateKey: normalizeGithubPrivateKey(privateKey),
+  };
+}
+
+function createGithubAppJwt(): string {
+  const config = getGithubAppConfig();
+  if (!config) {
+    throw new Error("GitHub App credentials are not configured on the server.");
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  return jwt.sign(
+    {
+      iat: now - 60,
+      exp: now + 9 * 60,
+      iss: config.appId,
+    },
+    config.privateKey,
+    {
+      algorithm: "RS256",
+      noTimestamp: true,
+    },
+  );
+}
+
+let cachedInstallationToken:
+  | {
+      token: string;
+      expiresAtMs: number;
+    }
+  | null = null;
+let cachedInstallationTokenPromise: Promise<string> | null = null;
+let cachedInstallationId: number | null = null;
+
+async function fetchGithubWithJwt(url: string, options: RequestInit = {}) {
+  const headers = new Headers(options.headers);
+  headers.set("Authorization", `Bearer ${createGithubAppJwt()}`);
+  headers.set("X-GitHub-Api-Version", GITHUB_API_VERSION);
+  headers.set("User-Agent", "sse-amendment-feature");
+
+  if (!headers.has("Accept")) {
+    headers.set("Accept", "application/vnd.github+json");
+  }
+  if (options.body && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  const response = await fetch(url, {
+    ...options,
+    headers,
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(
+      `GitHub App request failed (${response.status}): ${message}`,
+    );
+  }
+
+  return response;
+}
+
+async function resolveGithubInstallationId(): Promise<number> {
+  const config = getGithubAppConfig();
+  if (!config) {
+    throw new Error("GitHub App credentials are not configured on the server.");
+  }
+
+  if (config.installationId) {
+    cachedInstallationId = config.installationId;
+    return config.installationId;
+  }
+
+  if (cachedInstallationId) {
+    return cachedInstallationId;
+  }
+
+  const response = await fetchGithubWithJwt(
+    `${GOVERNING_DOCS_API}/installation`,
+    {
+      method: "GET",
+    },
+  );
+  const installation = (await response.json()) as GitHubInstallation;
+
+  if (!installation?.id) {
+    throw new Error(
+      `GitHub App is not installed on ${GOVERNING_DOC_OWNER}/${GOVERNING_DOC_REPO}.`,
+    );
+  }
+
+  cachedInstallationId = installation.id;
+  return installation.id;
+}
+
+async function getGithubInstallationToken(): Promise<string> {
+  if (
+    cachedInstallationToken &&
+    cachedInstallationToken.expiresAtMs - GITHUB_INSTALLATION_TOKEN_BUFFER_MS >
+      Date.now()
+  ) {
+    return cachedInstallationToken.token;
+  }
+
+  if (!cachedInstallationTokenPromise) {
+    cachedInstallationTokenPromise = (async () => {
+      const installationId = await resolveGithubInstallationId();
+      const response = await fetchGithubWithJwt(
+        `https://api.github.com/app/installations/${installationId}/access_tokens`,
+        {
+          method: "POST",
+        },
+      );
+      const token = (await response.json()) as GitHubInstallationToken;
+      const expiresAtMs = Date.parse(token.expires_at);
+
+      if (!token.token || Number.isNaN(expiresAtMs)) {
+        throw new Error("GitHub App did not return a valid installation token.");
+      }
+
+      cachedInstallationToken = {
+        token: token.token,
+        expiresAtMs,
+      };
+
+      return token.token;
+    })().finally(() => {
+      cachedInstallationTokenPromise = null;
+    });
+  }
+
+  return cachedInstallationTokenPromise;
+}
+
+async function getGithubToken(): Promise<string> {
+  if (getGithubAppConfig()) {
+    return getGithubInstallationToken();
+  }
+
+  const token = getLegacyGithubToken();
   if (!token) {
-    throw new Error("GITHUB_PAT is not configured on the server.");
+    throw new Error(
+      "Neither GitHub App credentials nor GITHUB_PAT are configured on the server.",
+    );
   }
   return token;
 }
 
 async function fetchGithub(url: string, options: RequestInit = {}) {
   const headers = new Headers(options.headers);
-  headers.set("Authorization", `Bearer ${getGithubToken()}`);
-  headers.set("X-GitHub-Api-Version", "2022-11-28");
+  headers.set("Authorization", `Bearer ${await getGithubToken()}`);
+  headers.set("X-GitHub-Api-Version", GITHUB_API_VERSION);
   headers.set("User-Agent", "sse-amendment-feature");
 
   if (!headers.has("Accept")) {
@@ -63,7 +264,9 @@ async function fetchGithub(url: string, options: RequestInit = {}) {
   });
   if (!response.ok) {
     const message = await response.text();
-    throw new Error(`GitHub API request failed (${response.status}): ${message}`);
+    throw new Error(
+      `GitHub API request failed (${response.status}): ${message}`,
+    );
   }
   return response;
 }
@@ -92,7 +295,9 @@ export async function fetchConstitutionSnapshot(): Promise<ConstitutionFileSnaps
   );
   const json = (await response.json()) as GitHubFileResponse;
   if (!json?.content || !json?.sha) {
-    throw new Error("GitHub API did not return a valid constitution file payload.");
+    throw new Error(
+      "GitHub API did not return a valid constitution file payload.",
+    );
   }
 
   const content = decodeBase64File(json.content.replace(/\n/g, ""));
@@ -103,9 +308,12 @@ export async function fetchConstitutionSnapshot(): Promise<ConstitutionFileSnaps
 }
 
 async function createAmendmentBranch(branchName: string): Promise<void> {
-  const baseRefResponse = await fetchGithub(`${GOVERNING_DOCS_API}/git/ref/heads/${GOVERNING_DOC_BRANCH}`, {
-    method: "GET",
-  });
+  const baseRefResponse = await fetchGithub(
+    `${GOVERNING_DOCS_API}/git/ref/heads/${GOVERNING_DOC_BRANCH}`,
+    {
+      method: "GET",
+    },
+  );
   const baseRef = (await baseRefResponse.json()) as GitHubRefResponse;
 
   await fetchGithub(`${GOVERNING_DOCS_API}/git/refs`, {
@@ -144,7 +352,8 @@ export async function createAmendmentPR(params: {
   proposedBy: string;
   branchName: string;
 }): Promise<AmendmentPRResult> {
-  const { title, description, proposedContent, proposedBy, branchName } = params;
+  const { title, description, proposedContent, proposedBy, branchName } =
+    params;
   const snapshot = await fetchConstitutionSnapshot();
   await createAmendmentBranch(branchName);
   await commitConstitutionToBranch({
@@ -179,12 +388,15 @@ export async function createAmendmentPR(params: {
 }
 
 export async function fetchPRDiff(prNumber: number): Promise<string> {
-  const response = await fetchGithub(`${GOVERNING_DOCS_API}/pulls/${prNumber}.diff`, {
-    method: "GET",
-    headers: {
-      Accept: "application/vnd.github.v3.diff",
+  const response = await fetchGithub(
+    `${GOVERNING_DOCS_API}/pulls/${prNumber}.diff`,
+    {
+      method: "GET",
+      headers: {
+        Accept: "application/vnd.github.v3.diff",
+      },
     },
-  });
+  );
 
   return response.text();
 }


### PR DESCRIPTION
## Summary
- fix persisted amendment diffs, voting window editing, new-amendment badges, and PR re-submission flows
- switch amendment GitHub auth to prefer a GitHub App installation token with repo-installation auto-discovery and keep PAT as a fallback during rollout
- add a minimal webhook endpoint plus env/docs updates for the new deployment contract

## Validation
- npm --prefix next run test -- amendments.route.test.ts githubAmendmentService.test.ts
- npm --prefix next run lint -- 'lib/services/githubAmendmentService.ts' 'app/api/github/webhooks/amendment-maker/route.ts' '__tests__/githubAmendmentService.test.ts' 'app/api/amendments/[id]/resubmit-pr/route.ts' 'components/amendments/AmendmentDetailClient.tsx' 'components/amendments/AmendmentCard.tsx' 'app/(main)/about/constitution/amendments/page.tsx' 'app/api/amendments/route.ts' 'app/api/amendments/[id]/route.ts' 'components/amendments/VotePanel.tsx' 'components/amendments/VotingDurationDialog.tsx' 'components/amendments/AmendmentWizard.tsx'
- npm --prefix next run typecheck *(currently fails on unrelated existing Prisma/library/tech-committee errors on development)*

Closes #467