### PR TITLE
Fix multi-position primary review votes

### DIFF
--- a/next/app/api/amendments/[id]/vote/route.ts
+++ b/next/app/api/amendments/[id]/vote/route.ts
@@ -32,68 +32,148 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     return new Response('"approve" must be true or false', { status: 422 });
   }
 
-  const amendment = await prisma.amendment.findUnique({
-    where: { id: amendmentId },
-    select: {
-      id: true,
-      status: true,
-      isSemanticChange: true,
-      votingEndsAt: true,
-    },
-  });
-  if (!amendment) {
-    return new Response("Amendment not found", { status: 404 });
-  }
-
-  // Determine voting phase from amendment status
-  let phase: string;
-  if (amendment.status === AmendmentStatus.PRIMARY_REVIEW) {
-    phase = "PRIMARY_REVIEW";
-  } else if (amendment.status === AmendmentStatus.VOTING) {
-    phase = "VOTING";
-  } else {
-    return new Response("Voting is not open for this amendment", { status: 409 });
-  }
-
-  // Block voting after the voting window has ended
-  if (phase === "VOTING" && amendment.votingEndsAt && new Date(amendment.votingEndsAt) < new Date()) {
-    return new Response("The voting window has ended", { status: 409 });
-  }
-
-  // PRIMARY_REVIEW: vote per officer position
-  if (phase === "PRIMARY_REVIEW") {
-    if (!actor.isPrimary) {
-      return new Response("Only primary officers can vote during primary review", { status: 403 });
-    }
-
-    const positionId = body.officerPositionId;
-    if (!positionId || typeof positionId !== "number") {
-      return new Response("officerPositionId is required for primary review votes", { status: 422 });
-    }
-
-    // Verify the actor actually holds this primary position
-    const officerRecord = await prisma.officer.findFirst({
-      where: {
-        user_id: actor.id,
-        is_active: true,
-        position_id: positionId,
-        position: { is_primary: true },
+  try {
+    const amendment = await prisma.amendment.findUnique({
+      where: { id: amendmentId },
+      select: {
+        id: true,
+        status: true,
+        isSemanticChange: true,
+        votingEndsAt: true,
       },
-      select: { id: true },
     });
-    if (!officerRecord) {
-      return new Response("You do not hold this primary officer position", { status: 403 });
+    if (!amendment) {
+      return new Response("Amendment not found", { status: 404 });
     }
 
-    // Upsert by position (one vote per position per amendment)
-    const existing = await prisma.amendmentVote.findFirst({
-      where: { amendmentId, officerPositionId: positionId, phase: "PRIMARY_REVIEW" },
+    let phase: string;
+    if (amendment.status === AmendmentStatus.PRIMARY_REVIEW) {
+      phase = "PRIMARY_REVIEW";
+    } else if (amendment.status === AmendmentStatus.VOTING) {
+      phase = "VOTING";
+    } else {
+      return new Response("Voting is not open for this amendment", { status: 409 });
+    }
+
+    if (phase === "VOTING" && amendment.votingEndsAt && new Date(amendment.votingEndsAt) < new Date()) {
+      return new Response("The voting window has ended", { status: 409 });
+    }
+
+    if (phase === "PRIMARY_REVIEW") {
+      if (!actor.isPrimary) {
+        return new Response("Only primary officers can vote during primary review", { status: 403 });
+      }
+
+      const positionId = body.officerPositionId;
+      if (!positionId || typeof positionId !== "number") {
+        return new Response("officerPositionId is required for primary review votes", { status: 422 });
+      }
+
+      const officerRecord = await prisma.officer.findFirst({
+        where: {
+          user_id: actor.id,
+          is_active: true,
+          position_id: positionId,
+          position: { is_primary: true },
+        },
+        select: { id: true },
+      });
+      if (!officerRecord) {
+        return new Response("You do not hold this primary officer position", { status: 403 });
+      }
+
+      const existing = await prisma.amendmentVote.findFirst({
+        where: { amendmentId, officerPositionId: positionId, phase: "PRIMARY_REVIEW" },
+        select: { id: true },
+      });
+
+      if (existing) {
+        await prisma.amendmentVote.update({
+          where: { id: existing.id },
+          data: { approve: body.approve, createdAt: new Date() },
+        });
+      } else {
+        await prisma.amendmentVote.create({
+          data: {
+            amendmentId,
+            userId: actor.id,
+            approve: body.approve,
+            phase: "PRIMARY_REVIEW",
+            officerPositionId: positionId,
+          },
+        });
+      }
+
+      const allPrimaryVotes = await prisma.amendmentVote.findMany({
+        where: { amendmentId, phase: "PRIMARY_REVIEW" },
+        select: {
+          approve: true,
+          officerPositionId: true,
+          user: { select: { id: true, name: true } },
+        },
+      });
+
+      const allPrimaryPositions = await prisma.officerPosition.findMany({
+        where: { is_primary: true },
+        select: {
+          id: true,
+          title: true,
+          officers: {
+            where: { is_active: true },
+            select: { user: { select: { id: true, name: true } } },
+          },
+        },
+        orderBy: { title: "asc" },
+      });
+
+      const positionSlots = allPrimaryPositions.map((pos) => {
+        const vote = allPrimaryVotes.find((v) => v.officerPositionId === pos.id);
+        const holder = pos.officers[0]?.user ?? null;
+        return {
+          positionId: pos.id,
+          title: pos.title,
+          holder: holder ? { id: holder.id, name: holder.name } : null,
+          voted: !!vote,
+          approve: vote?.approve ?? null,
+        };
+      });
+
+      const totalPositions = positionSlots.length;
+      const votedCount = positionSlots.filter((s) => s.voted).length;
+      const approveCount = positionSlots.filter((s) => s.approve === true).length;
+      const rejectCount = positionSlots.filter((s) => s.approve === false).length;
+      const quorumRequired = totalPositions === 0 ? 0 : Math.floor(totalPositions / 2) + 1;
+      const quorumMet = votedCount >= quorumRequired;
+
+      return Response.json({
+        status: amendment.status,
+        phase: "PRIMARY_REVIEW",
+        primaryReview: {
+          positionSlots,
+          totalPositions,
+          votedCount,
+          approveCount,
+          rejectCount,
+          quorumRequired,
+          quorumMet,
+          majorityApproves: quorumMet && approveCount > rejectCount,
+          majorityRejects: quorumMet && rejectCount >= approveCount,
+        },
+      });
+    }
+
+    if (phase === "VOTING" && !amendment.isSemanticChange && !actor.isPrimary) {
+      return new Response("Only primary officers can vote on non-semantic amendments", { status: 403 });
+    }
+
+    const existingMemberVote = await prisma.amendmentVote.findFirst({
+      where: { amendmentId, userId: actor.id, phase: "VOTING" },
       select: { id: true },
     });
 
-    if (existing) {
+    if (existingMemberVote) {
       await prisma.amendmentVote.update({
-        where: { id: existing.id },
+        where: { id: existingMemberVote.id },
         data: { approve: body.approve, createdAt: new Date() },
       });
     } else {
@@ -102,124 +182,42 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
           amendmentId,
           userId: actor.id,
           approve: body.approve,
-          phase: "PRIMARY_REVIEW",
-          officerPositionId: positionId,
+          phase: "VOTING",
         },
       });
     }
 
-    // Return updated position-level vote data
-    const allPrimaryVotes = await prisma.amendmentVote.findMany({
-      where: { amendmentId, phase: "PRIMARY_REVIEW" },
-      select: {
-        approve: true,
-        officerPositionId: true,
-        user: { select: { id: true, name: true } },
-      },
+    const updatedVotes = await prisma.amendmentVote.findMany({
+      where: { amendmentId, phase: "VOTING" },
+      select: { approve: true, userId: true },
     });
 
-    const allPrimaryPositions = await prisma.officerPosition.findMany({
-      where: { is_primary: true },
-      select: {
-        id: true,
-        title: true,
-        officers: {
-          where: { is_active: true },
-          select: { user: { select: { id: true, name: true } } },
-        },
-      },
-      orderBy: { title: "asc" },
-    });
-
-    const positionSlots = allPrimaryPositions.map((pos) => {
-      const vote = allPrimaryVotes.find((v) => v.officerPositionId === pos.id);
-      const holder = pos.officers[0]?.user ?? null;
-      return {
-        positionId: pos.id,
-        title: pos.title,
-        holder: holder ? { id: holder.id, name: holder.name } : null,
-        voted: !!vote,
-        approve: vote?.approve ?? null,
-      };
-    });
-
-    const totalPositions = positionSlots.length;
-    const votedCount = positionSlots.filter((s) => s.voted).length;
-    const approveCount = positionSlots.filter((s) => s.approve === true).length;
-    const rejectCount = positionSlots.filter((s) => s.approve === false).length;
-    const quorumRequired = totalPositions === 0 ? 0 : Math.floor(totalPositions / 2) + 1;
-    const quorumMet = votedCount >= quorumRequired;
+    const voteSummary = computeVoteSummary(updatedVotes);
+    const totalActiveMembers = await getActiveMemberCount();
+    const quorum = Math.ceil(totalActiveMembers * (2 / 3));
+    const quorumMet = voteSummary.totalVotes >= quorum || quorum === 0;
+    const supermajority = Math.ceil(voteSummary.totalVotes * (2 / 3));
 
     return Response.json({
       status: amendment.status,
-      phase: "PRIMARY_REVIEW",
-      primaryReview: {
-        positionSlots,
-        totalPositions,
-        votedCount,
-        approveCount,
-        rejectCount,
-        quorumRequired,
+      phase: "VOTING",
+      voteSummary: {
+        totalVotes: voteSummary.totalVotes,
+        approveVotes: voteSummary.approveVotes,
+        rejectVotes: voteSummary.rejectVotes,
+        quorum,
         quorumMet,
-        majorityApproves: quorumMet && approveCount > rejectCount,
-        majorityRejects: quorumMet && rejectCount >= approveCount,
+        supermajority,
+        isPassed: amendment.isSemanticChange
+          ? voteSummary.totalVotes >= quorum && voteSummary.approveVotes >= supermajority
+          : !voteSummary.totalVotes ? false : voteSummary.approveVotes > voteSummary.rejectVotes,
+        hasUserVoted: true,
+        userVote: body.approve,
       },
     });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to record vote";
+    return new Response(message, { status: 500 });
   }
-
-  // VOTING phase — member vote (per-user)
-  if (phase === "VOTING" && !amendment.isSemanticChange && !actor.isPrimary) {
-    return new Response("Only primary officers can vote on non-semantic amendments", { status: 403 });
-  }
-
-  // Upsert member vote (one per user in VOTING phase)
-  const existingMemberVote = await prisma.amendmentVote.findFirst({
-    where: { amendmentId, userId: actor.id, phase: "VOTING" },
-    select: { id: true },
-  });
-
-  if (existingMemberVote) {
-    await prisma.amendmentVote.update({
-      where: { id: existingMemberVote.id },
-      data: { approve: body.approve, createdAt: new Date() },
-    });
-  } else {
-    await prisma.amendmentVote.create({
-      data: {
-        amendmentId,
-        userId: actor.id,
-        approve: body.approve,
-        phase: "VOTING",
-      },
-    });
-  }
-
-  const updatedVotes = await prisma.amendmentVote.findMany({
-    where: { amendmentId, phase: "VOTING" },
-    select: { approve: true, userId: true },
-  });
-
-  const voteSummary = computeVoteSummary(updatedVotes);
-  const totalActiveMembers = await getActiveMemberCount();
-  const quorum = Math.ceil(totalActiveMembers * (2 / 3));
-  const quorumMet = voteSummary.totalVotes >= quorum || quorum === 0;
-  const supermajority = Math.ceil(voteSummary.totalVotes * (2 / 3));
-
-  return Response.json({
-    status: amendment.status,
-    phase: "VOTING",
-    voteSummary: {
-      totalVotes: voteSummary.totalVotes,
-      approveVotes: voteSummary.approveVotes,
-      rejectVotes: voteSummary.rejectVotes,
-      quorum,
-      quorumMet,
-      supermajority,
-      isPassed: amendment.isSemanticChange
-        ? voteSummary.totalVotes >= quorum && voteSummary.approveVotes >= supermajority
-        : !voteSummary.totalVotes ? false : voteSummary.approveVotes > voteSummary.rejectVotes,
-      hasUserVoted: true,
-      userVote: body.approve,
-    },
-  });
 }

--- a/next/components/amendments/VotePanel.tsx
+++ b/next/components/amendments/VotePanel.tsx
@@ -332,6 +332,19 @@ export default function VotePanel({
 
   const requiredApproveVotes = Math.ceil((2 / 3) * localTotals.totalVotes);
 
+  async function readResponsePayload(response: Response) {
+    const raw = await response.text();
+    if (!raw) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      return raw;
+    }
+  }
+
   async function castVote(approve: boolean) {
     setSubmitting(true);
     try {
@@ -340,16 +353,30 @@ export default function VotePanel({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ approve }),
       });
-      const payload = await response.json();
+      const payload = await readResponsePayload(response);
       if (!response.ok) {
-        throw new Error(payload?.error ?? payload ?? "Could not record vote");
+        throw new Error(
+          typeof payload === "object" && payload !== null
+            ? ((payload.error as string | undefined) ??
+              (payload.message as string | undefined) ??
+              "Could not record vote")
+            : ((payload as string | null) ?? "Could not record vote"),
+        );
       }
+      const voteSummary =
+        typeof payload === "object" && payload !== null
+          ? (payload.voteSummary as
+              | {
+                  totalVotes?: number;
+                  approveVotes?: number;
+                  rejectVotes?: number;
+                }
+              | undefined)
+          : undefined;
       setLocalTotals({
-        totalVotes: payload?.voteSummary?.totalVotes ?? localTotals.totalVotes,
-        approveVotes:
-          payload?.voteSummary?.approveVotes ?? localTotals.approveVotes,
-        rejectVotes:
-          payload?.voteSummary?.rejectVotes ?? localTotals.rejectVotes,
+        totalVotes: voteSummary?.totalVotes ?? localTotals.totalVotes,
+        approveVotes: voteSummary?.approveVotes ?? localTotals.approveVotes,
+        rejectVotes: voteSummary?.rejectVotes ?? localTotals.rejectVotes,
       });
       setLocalUserVote(approve);
     } catch (err) {
@@ -367,12 +394,24 @@ export default function VotePanel({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ approve, officerPositionId: positionId }),
       });
-      const payload = await response.json();
+      const payload = await readResponsePayload(response);
       if (!response.ok) {
-        throw new Error(payload?.error ?? payload ?? "Could not record vote");
+        throw new Error(
+          typeof payload === "object" && payload !== null
+            ? ((payload.error as string | undefined) ??
+              (payload.message as string | undefined) ??
+              "Could not record vote")
+            : ((payload as string | null) ?? "Could not record vote"),
+        );
       }
-      if (payload.primaryReview) {
-        setLocalPrimaryReview(payload.primaryReview);
+      if (
+        typeof payload === "object" &&
+        payload !== null &&
+        payload.primaryReview
+      ) {
+        setLocalPrimaryReview(
+          payload.primaryReview as VotePanelProps["primaryReview"],
+        );
       }
     } catch (err) {
       alert(err instanceof Error ? err.message : "Could not record vote");

--- a/next/prisma/migrations/20260416041000_fix_primary_review_multi_position_votes/migration.sql
+++ b/next/prisma/migrations/20260416041000_fix_primary_review_multi_position_votes/migration.sql
@@ -1,0 +1,12 @@
+-- Primary review votes are per officer position, not per user.
+-- A single user may hold multiple primary positions and must be able to vote once per position.
+DROP INDEX IF EXISTS "AmendmentVote_amendmentId_userId_phase_key";
+DROP INDEX IF EXISTS "AmendmentVote_amendmentId_userId_key";
+
+CREATE UNIQUE INDEX IF NOT EXISTS "AmendmentVote_amendmentId_userId_voting_key"
+  ON "AmendmentVote"("amendmentId", "userId")
+  WHERE phase = 'VOTING';
+
+CREATE UNIQUE INDEX IF NOT EXISTS "AmendmentVote_amendmentId_officerPositionId_phase_key"
+  ON "AmendmentVote"("amendmentId", "officerPositionId", phase)
+  WHERE "officerPositionId" IS NOT NULL;

--- a/next/prisma/schema.prisma
+++ b/next/prisma/schema.prisma
@@ -886,8 +886,6 @@ model AmendmentVote {
   amendment       Amendment        @relation(fields: [amendmentId], references: [id], onDelete: Cascade)
   user            User             @relation(fields: [userId], references: [id])
   officerPosition OfficerPosition? @relation(fields: [officerPositionId], references: [id])
-
-  @@unique([amendmentId, userId, phase])
 }
 
 model AmendmentComment {


### PR DESCRIPTION
## Summary
- allow one primary review vote per held officer position instead of one per user
- return real server error text from the amendment vote API on failures
- harden the vote panel to handle non-JSON error responses cleanly

## Validation
- npm --prefix next run lint -- 'app/api/amendments/[id]/vote/route.ts' 'components/amendments/VotePanel.tsx'