### PR TITLE
Promote development to main: amendments feature, deploy fixes, dep bumps

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -19,21 +19,23 @@ jobs:
 
       - name: Set branch variables
         run: |
+          # DEPLOY_PATH and host targets are the same for both environments —
+          # `website` (prod) and `website-dev` are services in the same
+          # docker-compose stack at /home/administrator/deploy on the
+          # docker-host VM (reached via SSH ProxyJump through eggs).
           if [ "${GITHUB_REF_NAME}" = "main" ]; then
             echo "IMAGE_TAG=prod" >> $GITHUB_ENV
             echo "NEXTAUTH_URL=https://sse.rit.edu" >> $GITHUB_ENV
             echo "NEXT_PUBLIC_ENV=prod" >> $GITHUB_ENV
-            echo "DEPLOY_PATH=/home/sse-deploy/deploy" >> $GITHUB_ENV
             echo "DEPLOY_SERVICE=website" >> $GITHUB_ENV
-            echo "GIT_COMMIT=${GITHUB_SHA::7}" >> $GITHUB_ENV
           else
             echo "IMAGE_TAG=dev" >> $GITHUB_ENV
             echo "NEXTAUTH_URL=https://ssedev.se.rit.edu" >> $GITHUB_ENV
             echo "NEXT_PUBLIC_ENV=dev" >> $GITHUB_ENV
-            echo "DEPLOY_PATH=/home/sse-deploy/deploy" >> $GITHUB_ENV
             echo "DEPLOY_SERVICE=website-dev" >> $GITHUB_ENV
-            echo "GIT_COMMIT=${GITHUB_SHA::7}" >> $GITHUB_ENV
           fi
+          echo "DEPLOY_PATH=/home/administrator/deploy" >> $GITHUB_ENV
+          echo "GIT_COMMIT=${GITHUB_SHA::7}" >> $GITHUB_ENV
 
       - name: Build image
         working-directory: ./next
@@ -58,9 +60,15 @@ jobs:
         if: github.event_name == 'push'
         uses: appleboy/ssh-action@v1.0.3
         with:
+          # Final target: administrator@192.168.111.2 (docker-host VM, private IP).
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SSE_DEPLOY_KEY }}
+          # Jump via eggs.se.rit.edu because the docker-host lives on a
+          # private subnet and isn't reachable from GitHub runners directly.
+          proxy_host: ${{ secrets.PROXY_HOST }}
+          proxy_username: ${{ secrets.PROXY_USER }}
+          proxy_key: ${{ secrets.SSE_DEPLOY_KEY }}
           script: |
             cd ${{ env.DEPLOY_PATH }}
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.repository_owner }}" --password-stdin

--- a/documentation/EnvironmentSetup.md
+++ b/documentation/EnvironmentSetup.md
@@ -47,7 +47,11 @@ DATABASE_URL="postgresql://postgres:postgres@localhost:5432/ssequel_dev"
 NEXTAUTH_URL="http://localhost:3000"
 NEXTAUTH_SECRET="replace-with-a-long-random-secret"
 SESSION_COOKIE_NAME="next-auth.session-token"
-GITHUB_PAT="server-side GitHub PAT for constitution amendments"
+GITHUB_APP_ID=""
+GITHUB_APP_PRIVATE_KEY=""
+GITHUB_APP_INSTALLATION_ID=""
+GITHUB_WEBHOOK_SECRET=""
+GITHUB_PAT=""
 
 # Google OAuth
 GOOGLE_CLIENT_ID=""
@@ -123,9 +127,19 @@ You do **not** need PostgreSQL installed directly on your computer if you use Do
 
 If you are using the constitution amendment workflow:
 
-- Create a server-side GitHub PAT with `repo` scope for write access to `rit-sse/governing-docs`.
-- Set `GITHUB_PAT` in the runtime environment for the Next.js container.
-- Keep this token out of source control and never expose it in client-side code.
+- Preferred: create a private GitHub App installed on `rit-sse/governing-docs`.
+- Grant repository permissions:
+  - `Contents: Read and write`
+  - `Pull requests: Read and write`
+- Set these runtime env vars on the Next.js container:
+  - `GITHUB_APP_ID`
+  - `GITHUB_APP_PRIVATE_KEY`
+  - `GITHUB_WEBHOOK_SECRET`
+- Optional:
+  - `GITHUB_APP_INSTALLATION_ID` if you want to pin the installation instead of letting the app auto-discover its installation on `rit-sse/governing-docs`
+- Legacy fallback:
+  - `GITHUB_PAT` still works if GitHub App env vars are not set, but the GitHub App flow is the deployment target going forward.
+- Keep all secrets out of source control and never expose them in client-side code.
 
 Example compose-style deployment snippet:
 
@@ -133,7 +147,10 @@ Example compose-style deployment snippet:
 services:
   website:
     environment:
-      GITHUB_PAT: ${GITHUB_PAT}
+      GITHUB_APP_ID: ${GITHUB_APP_ID}
+      GITHUB_APP_PRIVATE_KEY: ${GITHUB_APP_PRIVATE_KEY}
+      GITHUB_WEBHOOK_SECRET: ${GITHUB_WEBHOOK_SECRET}
+      GITHUB_APP_INSTALLATION_ID: ${GITHUB_APP_INSTALLATION_ID}
 ```
 
 ## Setting up Google OAuth

--- a/next/.env.example
+++ b/next/.env.example
@@ -5,6 +5,11 @@ DATABASE_URL="postgresql://postgres:postgres@localhost:5432/ssequel_dev"
 NEXTAUTH_URL="http://localhost:3000"
 NEXTAUTH_SECRET="replace-with-a-long-random-secret"
 SESSION_COOKIE_NAME="next-auth.session-token"
+GITHUB_APP_ID=""
+GITHUB_APP_PRIVATE_KEY=""
+GITHUB_APP_INSTALLATION_ID=""
+GITHUB_WEBHOOK_SECRET=""
+GITHUB_PAT=""
 
 # Google OAuth
 GOOGLE_CLIENT_ID=""

--- a/next/__tests__/amendments.route.test.ts
+++ b/next/__tests__/amendments.route.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockGetActorFromRequest,
+  mockComputeVoteSummary,
+  mockGetActiveMemberCount,
+  mockCreateAmendmentPR,
+  mockFetchConstitutionSnapshot,
+  mockAmendmentCreate,
+  mockAmendmentFindUnique,
+  mockAmendmentUpdate,
+  mockAmendmentVoteFindMany,
+  mockOfficerPositionCount,
+} = vi.hoisted(() => ({
+  mockGetActorFromRequest: vi.fn(),
+  mockComputeVoteSummary: vi.fn(),
+  mockGetActiveMemberCount: vi.fn(),
+  mockCreateAmendmentPR: vi.fn(),
+  mockFetchConstitutionSnapshot: vi.fn(),
+  mockAmendmentCreate: vi.fn(),
+  mockAmendmentFindUnique: vi.fn(),
+  mockAmendmentUpdate: vi.fn(),
+  mockAmendmentVoteFindMany: vi.fn(),
+  mockOfficerPositionCount: vi.fn(),
+}));
+
+vi.mock("@/lib/services/amendmentService", () => ({
+  getActorFromRequest: mockGetActorFromRequest,
+  computeVoteSummary: mockComputeVoteSummary,
+  getActiveMemberCount: mockGetActiveMemberCount,
+  getActivePrimaryOfficerCount: vi.fn(),
+  computePrimaryReviewResult: vi.fn(),
+}));
+
+vi.mock("@/lib/services/githubAmendmentService", () => ({
+  buildAmendmentBranchName: vi.fn(() => "amendment-55-retry-branch"),
+  createAmendmentPR: mockCreateAmendmentPR,
+  fetchConstitutionSnapshot: mockFetchConstitutionSnapshot,
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    amendment: {
+      create: mockAmendmentCreate,
+      findUnique: mockAmendmentFindUnique,
+      update: mockAmendmentUpdate,
+    },
+    amendmentVote: {
+      findMany: mockAmendmentVoteFindMany,
+    },
+    officerPosition: {
+      count: mockOfficerPositionCount,
+    },
+  },
+}));
+
+import { POST } from "@/app/api/amendments/route";
+import { PATCH } from "@/app/api/amendments/[id]/route";
+import { POST as resubmitPOST } from "@/app/api/amendments/[id]/resubmit-pr/route";
+
+describe("/api/amendments routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetActorFromRequest.mockResolvedValue({
+      id: 7,
+      isMember: true,
+      isPrimary: true,
+      isSeAdmin: false,
+    });
+    mockComputeVoteSummary.mockReturnValue({
+      totalVotes: 0,
+      approveVotes: 0,
+      rejectVotes: 0,
+    });
+    mockGetActiveMemberCount.mockResolvedValue(30);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("POST persists the client baseline when GitHub snapshot creation fails", async () => {
+    mockFetchConstitutionSnapshot.mockRejectedValue(
+      new Error("github offline"),
+    );
+    mockCreateAmendmentPR.mockRejectedValue(new Error("pr create failed"));
+    mockAmendmentCreate.mockResolvedValue({ id: 42 });
+    mockAmendmentFindUnique.mockResolvedValue({
+      id: 42,
+      title: "Presidential Running Mate Appointment",
+      status: "PRIMARY_REVIEW",
+      githubPrNumber: null,
+      githubBranch: null,
+    });
+
+    const res = await POST(
+      new Request("http://localhost/api/amendments", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          title: "Presidential Running Mate Appointment",
+          description: "Adds a VP appointment flow.",
+          originalContent: "# SSE Constitution\n\nCurrent text",
+          proposedContent: "# SSE Constitution\n\nUpdated text",
+          isSemanticChange: true,
+        }),
+      }) as any,
+    );
+
+    expect(res.status).toBe(201);
+    expect(mockAmendmentCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        originalContent: "# SSE Constitution\n\nCurrent text",
+        proposedContent: "# SSE Constitution\n\nUpdated text",
+      }),
+    });
+  });
+
+  it("PATCH allows primary officers to edit the voting window while voting is live", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-15T16:30:00.000Z"));
+
+    mockAmendmentFindUnique.mockResolvedValue({
+      id: 12,
+      status: "VOTING",
+      authorId: 7,
+      publishedAt: new Date("2026-04-15T12:00:00.000Z"),
+      votingOpenedAt: new Date("2026-04-15T13:00:00.000Z"),
+    });
+    mockAmendmentUpdate.mockResolvedValue({
+      id: 12,
+      status: "VOTING",
+    });
+
+    const res = await PATCH(
+      new Request("http://localhost/api/amendments/12", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          status: "VOTING",
+          votingDurationHours: 72,
+          resetVotingWindowFromNow: true,
+        }),
+      }) as any,
+      { params: Promise.resolve({ id: "12" }) },
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockAmendmentUpdate).toHaveBeenCalledWith({
+      where: { id: 12 },
+      data: expect.objectContaining({
+        status: "VOTING",
+        votingDurationHours: 72,
+        votingClosedAt: null,
+        votingEndsAt: new Date("2026-04-18T16:30:00.000Z"),
+      }),
+    });
+  });
+
+  it("POST can re-submit a missing amendment PR for the author", async () => {
+    mockGetActorFromRequest.mockResolvedValue({
+      id: 7,
+      isMember: true,
+      isPrimary: false,
+      isSeAdmin: false,
+    });
+    mockAmendmentFindUnique.mockResolvedValue({
+      id: 55,
+      title: "Presidential Running Mate Appointment",
+      description: "Adds a VP appointment flow.",
+      proposedContent: "# SSE Constitution\n\nUpdated text",
+      authorId: 7,
+      githubPrNumber: null,
+      status: "PRIMARY_REVIEW",
+    });
+    mockCreateAmendmentPR.mockResolvedValue({
+      branch: "amendment-55-retry-branch",
+      prNumber: 123,
+      prUrl: "https://github.com/rit-sse/governing-docs/pull/123",
+      originalContent: "# SSE Constitution\n\nCurrent text",
+    });
+    mockAmendmentUpdate.mockResolvedValue({
+      id: 55,
+      githubBranch: "amendment-55-retry-branch",
+      githubPrNumber: 123,
+      originalContent: "# SSE Constitution\n\nCurrent text",
+    });
+
+    const res = await resubmitPOST(
+      new Request("http://localhost/api/amendments/55/resubmit-pr", {
+        method: "POST",
+      }) as any,
+      { params: Promise.resolve({ id: "55" }) },
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockCreateAmendmentPR).toHaveBeenCalledWith({
+      title: "Presidential Running Mate Appointment",
+      description: "Adds a VP appointment flow.",
+      proposedContent: "# SSE Constitution\n\nUpdated text",
+      proposedBy: "Member #7",
+      branchName: "amendment-55-retry-branch",
+    });
+    expect(mockAmendmentUpdate).toHaveBeenCalledWith({
+      where: { id: 55 },
+      data: {
+        githubBranch: "amendment-55-retry-branch",
+        githubPrNumber: 123,
+        originalContent: "# SSE Constitution\n\nCurrent text",
+      },
+      select: {
+        id: true,
+        githubBranch: true,
+        githubPrNumber: true,
+        originalContent: true,
+      },
+    });
+  });
+});

--- a/next/__tests__/amendments.route.test.ts
+++ b/next/__tests__/amendments.route.test.ts
@@ -83,9 +83,7 @@ describe("/api/amendments routes", () => {
     mockFetchConstitutionSnapshot.mockRejectedValue(
       new Error("github offline"),
     );
-    mockCreateAmendmentPR.mockRejectedValue(new Error("pr create failed"));
-    mockAmendmentCreate.mockResolvedValue({ id: 42 });
-    mockAmendmentFindUnique.mockResolvedValue({
+    mockAmendmentCreate.mockResolvedValue({
       id: 42,
       title: "Presidential Running Mate Appointment",
       status: "PRIMARY_REVIEW",
@@ -113,7 +111,15 @@ describe("/api/amendments routes", () => {
         originalContent: "# SSE Constitution\n\nCurrent text",
         proposedContent: "# SSE Constitution\n\nUpdated text",
       }),
+      select: {
+        id: true,
+        title: true,
+        status: true,
+        githubPrNumber: true,
+        githubBranch: true,
+      },
     });
+    expect(mockCreateAmendmentPR).not.toHaveBeenCalled();
   });
 
   it("PATCH allows primary officers to edit the voting window while voting is live", async () => {
@@ -157,6 +163,123 @@ describe("/api/amendments routes", () => {
     });
   });
 
+  it("PATCH allows quorum-stage text edits before voting opens", async () => {
+    mockFetchConstitutionSnapshot.mockResolvedValue({
+      content: "# SSE Constitution\n\nCurrent baseline",
+      sha: "baseline-sha",
+    });
+    mockAmendmentFindUnique.mockResolvedValue({
+      id: 21,
+      status: "PRIMARY_REVIEW",
+      authorId: 7,
+      title: "Original title",
+      description: "Original description",
+      proposedContent: "# SSE Constitution\n\nOld text",
+      githubPrNumber: null,
+      publishedAt: new Date("2026-04-15T12:00:00.000Z"),
+      votingOpenedAt: null,
+    });
+    mockAmendmentUpdate.mockResolvedValue({
+      id: 21,
+      status: "PRIMARY_REVIEW",
+      title: "Updated title",
+      description: "Updated description",
+      proposedContent: "# SSE Constitution\n\nUpdated text",
+    });
+
+    const res = await PATCH(
+      new Request("http://localhost/api/amendments/21", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          title: "Updated title",
+          description: "Updated description",
+          proposedContent: "# SSE Constitution\n\nUpdated text",
+        }),
+      }) as any,
+      { params: Promise.resolve({ id: "21" }) },
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockAmendmentUpdate).toHaveBeenCalledWith({
+      where: { id: 21 },
+      data: expect.objectContaining({
+        title: "Updated title",
+        description: "Updated description",
+        proposedContent: "# SSE Constitution\n\nUpdated text",
+        originalContent: "# SSE Constitution\n\nCurrent baseline",
+      }),
+    });
+    expect(mockCreateAmendmentPR).not.toHaveBeenCalled();
+  });
+
+  it("PATCH opens voting and creates the GitHub PR after quorum passes", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-15T18:00:00.000Z"));
+
+    mockAmendmentFindUnique.mockResolvedValue({
+      id: 34,
+      status: "PRIMARY_REVIEW",
+      authorId: 7,
+      title: "Presidential Running Mate Appointment",
+      description: "Adds a VP appointment flow.",
+      proposedContent: "# SSE Constitution\n\nUpdated text",
+      githubPrNumber: null,
+      publishedAt: new Date("2026-04-15T12:00:00.000Z"),
+      votingOpenedAt: null,
+    });
+    mockAmendmentVoteFindMany.mockResolvedValue([
+      { approve: true },
+      { approve: true },
+    ]);
+    mockOfficerPositionCount.mockResolvedValue(3);
+    mockCreateAmendmentPR.mockResolvedValue({
+      branch: "amendment-55-retry-branch",
+      prNumber: 123,
+      prUrl: "https://github.com/rit-sse/governing-docs/pull/123",
+      originalContent: "# SSE Constitution\n\nCurrent text",
+    });
+    mockAmendmentUpdate.mockResolvedValue({
+      id: 34,
+      status: "VOTING",
+      githubPrNumber: 123,
+      githubBranch: "amendment-55-retry-branch",
+    });
+
+    const res = await PATCH(
+      new Request("http://localhost/api/amendments/34", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          status: "VOTING",
+          votingDurationHours: 72,
+        }),
+      }) as any,
+      { params: Promise.resolve({ id: "34" }) },
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockCreateAmendmentPR).toHaveBeenCalledWith({
+      title: "Presidential Running Mate Appointment",
+      description: "Adds a VP appointment flow.",
+      proposedContent: "# SSE Constitution\n\nUpdated text",
+      proposedBy: "Member #7",
+      branchName: "amendment-55-retry-branch",
+    });
+    expect(mockAmendmentUpdate).toHaveBeenCalledWith({
+      where: { id: 34 },
+      data: expect.objectContaining({
+        status: "VOTING",
+        primaryReviewClosedAt: new Date("2026-04-15T18:00:00.000Z"),
+        votingOpenedAt: new Date("2026-04-15T18:00:00.000Z"),
+        votingDurationHours: 72,
+        githubPrNumber: 123,
+        githubBranch: "amendment-55-retry-branch",
+        originalContent: "# SSE Constitution\n\nCurrent text",
+      }),
+    });
+  });
+
   it("POST can re-submit a missing amendment PR for the author", async () => {
     mockGetActorFromRequest.mockResolvedValue({
       id: 7,
@@ -171,7 +294,7 @@ describe("/api/amendments routes", () => {
       proposedContent: "# SSE Constitution\n\nUpdated text",
       authorId: 7,
       githubPrNumber: null,
-      status: "PRIMARY_REVIEW",
+      status: "VOTING",
     });
     mockCreateAmendmentPR.mockResolvedValue({
       branch: "amendment-55-retry-branch",

--- a/next/__tests__/githubAmendmentService.test.ts
+++ b/next/__tests__/githubAmendmentService.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const signMock = vi.fn(() => "app-jwt");
+
+vi.mock("jsonwebtoken", () => ({
+  default: {
+    sign: signMock,
+  },
+}));
+
+describe("githubAmendmentService auth", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.unstubAllGlobals();
+  });
+
+  it("uses GitHub App installation auth when app env is configured", async () => {
+    process.env.GITHUB_APP_ID = "3394606";
+    process.env.GITHUB_APP_PRIVATE_KEY =
+      "-----BEGIN RSA PRIVATE KEY-----\\nline-one\\nline-two\\n-----END RSA PRIVATE KEY-----";
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: 987654 }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            token: "installation-token",
+            expires_at: "2099-01-01T00:00:00.000Z",
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            content: Buffer.from("Constitution text").toString("base64"),
+            sha: "constitution-sha",
+            encoding: "base64",
+          }),
+          { status: 200 },
+        ),
+      );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { fetchConstitutionSnapshot } = await import(
+      "@/lib/services/githubAmendmentService"
+    );
+    const snapshot = await fetchConstitutionSnapshot();
+
+    expect(snapshot).toEqual({
+      content: "Constitution text",
+      sha: "constitution-sha",
+    });
+    expect(signMock).toHaveBeenCalledTimes(2);
+    expect(signMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        iss: "3394606",
+      }),
+      expect.stringContaining("\n"),
+      expect.objectContaining({
+        algorithm: "RS256",
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.github.com/repos/rit-sse/governing-docs/installation",
+      expect.objectContaining({
+        headers: expect.any(Headers),
+        method: "GET",
+      }),
+    );
+    expect(
+      (fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)?.headers,
+    ).toEqual(
+      expect.objectContaining({
+        get: expect.any(Function),
+      }),
+    );
+    expect(
+      (
+        (fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)
+          ?.headers as Headers
+      ).get("Authorization"),
+    ).toBe("Bearer app-jwt");
+    expect(
+      (
+        (fetchMock.mock.calls[1]?.[1] as RequestInit | undefined)
+          ?.headers as Headers
+      ).get("Authorization"),
+    ).toBe("Bearer app-jwt");
+    expect(
+      (
+        (fetchMock.mock.calls[2]?.[1] as RequestInit | undefined)
+          ?.headers as Headers
+      ).get("Authorization"),
+    ).toBe("Bearer installation-token");
+  });
+
+  it("falls back to GITHUB_PAT when no app env is configured", async () => {
+    process.env.GITHUB_PAT = "legacy-token";
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          content: Buffer.from("Constitution text").toString("base64"),
+          sha: "constitution-sha",
+          encoding: "base64",
+        }),
+        { status: 200 },
+      ),
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { fetchConstitutionSnapshot } = await import(
+      "@/lib/services/githubAmendmentService"
+    );
+    await fetchConstitutionSnapshot();
+
+    expect(signMock).not.toHaveBeenCalled();
+    expect(
+      (
+        (fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)
+          ?.headers as Headers
+      ).get("Authorization"),
+    ).toBe("Bearer legacy-token");
+  });
+});

--- a/next/app/(main)/about/constitution/amendments/page.tsx
+++ b/next/app/(main)/about/constitution/amendments/page.tsx
@@ -46,7 +46,7 @@ export default async function AmendmentsListPage() {
   if (authLevel.userId) {
     for (const amendment of amendments) {
       const vote = amendment.votes.find(
-        (v) => v.userId === authLevel.userId && v.phase === "VOTING"
+        (v) => v.userId === authLevel.userId && v.phase === "VOTING",
       );
       if (vote) {
         userVotes[amendment.id] = vote.approve;
@@ -55,26 +55,30 @@ export default async function AmendmentsListPage() {
   }
 
   const emptyRole = authLevel.isSeAdmin
-    ? "seAdmin" as const
+    ? ("seAdmin" as const)
     : authLevel.isPrimary
-      ? "primary" as const
+      ? ("primary" as const)
       : authLevel.isOfficer
-        ? "officer" as const
+        ? ("officer" as const)
         : authLevel.isMember
-          ? "member" as const
+          ? ("member" as const)
           : authLevel.isUser
-            ? "signedIn" as const
-            : "anonymous" as const;
+            ? ("signedIn" as const)
+            : ("anonymous" as const);
 
-  const activeRows = rows.filter((r) => r.status !== "WITHDRAWN" && r.status !== "REJECTED");
-  const withdrawnRows = rows.filter((r) => r.status === "WITHDRAWN" || r.status === "REJECTED");
+  const activeRows = rows.filter(
+    (r) => r.status !== "WITHDRAWN" && r.status !== "REJECTED",
+  );
+  const withdrawnRows = rows.filter(
+    (r) => r.status === "WITHDRAWN" || r.status === "REJECTED",
+  );
 
   return (
-    <section className="w-full max-w-6xl px-2 md:px-4">
+    <section className="w-full max-w-6xl px-3 sm:px-4">
       {/* Page header */}
-      <div className="py-4 flex flex-wrap gap-3 justify-between items-center">
+      <div className="flex flex-col gap-3 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h1 className="text-3xl font-display font-bold tracking-tight">
+          <h1 className="text-2xl font-display font-bold tracking-tight sm:text-3xl">
             Constitutional Amendments
           </h1>
           <p className="text-sm text-muted-foreground mt-1">
@@ -82,8 +86,11 @@ export default async function AmendmentsListPage() {
           </p>
         </div>
         {authLevel.isMember && (
-          <Button asChild>
-            <Link href="/about/constitution/amendments/new" className="flex items-center gap-2">
+          <Button asChild className="w-full sm:w-auto">
+            <Link
+              href="/about/constitution/amendments/new"
+              className="flex items-center gap-2"
+            >
               <Plus className="h-4 w-4" />
               Propose Amendment
             </Link>
@@ -98,7 +105,9 @@ export default async function AmendmentsListPage() {
         ) : (
           <>
             {activeRows.length === 0 ? (
-              <p className="text-sm text-muted-foreground py-4 text-center">No active amendments right now.</p>
+              <p className="text-sm text-muted-foreground py-4 text-center">
+                No active amendments right now.
+              </p>
             ) : (
               <div className="space-y-3">
                 {activeRows.map((amendment) => (

--- a/next/app/api/amendments/[id]/resubmit-pr/route.ts
+++ b/next/app/api/amendments/[id]/resubmit-pr/route.ts
@@ -54,12 +54,11 @@ export async function POST(
   }
 
   if (
-    amendment.status === AmendmentStatus.MERGED ||
-    amendment.status === AmendmentStatus.WITHDRAWN ||
-    amendment.status === AmendmentStatus.REJECTED
+    amendment.status !== AmendmentStatus.VOTING &&
+    amendment.status !== AmendmentStatus.APPROVED
   ) {
     return new Response(
-      "This amendment is no longer eligible for PR re-submission",
+      "A PR can only be created after quorum has passed and member voting is open.",
       { status: 409 },
     );
   }

--- a/next/app/api/amendments/[id]/resubmit-pr/route.ts
+++ b/next/app/api/amendments/[id]/resubmit-pr/route.ts
@@ -1,0 +1,103 @@
+import prisma from "@/lib/prisma";
+import { AmendmentStatus } from "@prisma/client";
+import { NextRequest } from "next/server";
+import { getActorFromRequest } from "@/lib/services/amendmentService";
+import {
+  buildAmendmentBranchName,
+  createAmendmentPR,
+} from "@/lib/services/githubAmendmentService";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const amendmentId = Number(id);
+  if (Number.isNaN(amendmentId)) {
+    return new Response("Invalid amendment id", { status: 422 });
+  }
+
+  const actor = await getActorFromRequest(request);
+  if (!actor) {
+    return new Response("Authentication required", { status: 401 });
+  }
+
+  const amendment = await prisma.amendment.findUnique({
+    where: { id: amendmentId },
+    select: {
+      id: true,
+      title: true,
+      description: true,
+      proposedContent: true,
+      authorId: true,
+      githubPrNumber: true,
+      status: true,
+    },
+  });
+  if (!amendment) {
+    return new Response("Amendment not found", { status: 404 });
+  }
+
+  if (!actor.isPrimary && !actor.isSeAdmin && amendment.authorId !== actor.id) {
+    return new Response(
+      "Only the author, a primary officer, or an SE admin can re-submit a PR",
+      { status: 403 },
+    );
+  }
+
+  if (amendment.githubPrNumber) {
+    return new Response("This amendment already has a linked pull request", {
+      status: 409,
+    });
+  }
+
+  if (
+    amendment.status === AmendmentStatus.MERGED ||
+    amendment.status === AmendmentStatus.WITHDRAWN ||
+    amendment.status === AmendmentStatus.REJECTED
+  ) {
+    return new Response(
+      "This amendment is no longer eligible for PR re-submission",
+      { status: 409 },
+    );
+  }
+
+  const branchName = buildAmendmentBranchName(amendment.title, amendment.id);
+  const proposedBy = `Member #${amendment.authorId}`;
+  const prBody =
+    amendment.description ||
+    `${amendment.title}\n\nAmendment proposal by ${proposedBy}.`;
+
+  try {
+    const { prNumber, originalContent } = await createAmendmentPR({
+      title: amendment.title,
+      description: prBody,
+      proposedContent: amendment.proposedContent,
+      proposedBy,
+      branchName,
+    });
+
+    const updated = await prisma.amendment.update({
+      where: { id: amendment.id },
+      data: {
+        githubBranch: branchName,
+        githubPrNumber: prNumber,
+        originalContent,
+      },
+      select: {
+        id: true,
+        githubBranch: true,
+        githubPrNumber: true,
+        originalContent: true,
+      },
+    });
+
+    return Response.json(updated);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to re-submit PR";
+    return new Response(message, { status: 500 });
+  }
+}

--- a/next/app/api/amendments/[id]/route.ts
+++ b/next/app/api/amendments/[id]/route.ts
@@ -4,10 +4,13 @@ import { NextRequest } from "next/server";
 import {
   computeVoteSummary,
   getActiveMemberCount,
-  getActivePrimaryOfficerCount,
-  computePrimaryReviewResult,
   getActorFromRequest,
 } from "@/lib/services/amendmentService";
+import {
+  buildAmendmentBranchName,
+  createAmendmentPR,
+  fetchConstitutionSnapshot,
+} from "@/lib/services/githubAmendmentService";
 
 export const dynamic = "force-dynamic";
 
@@ -31,6 +34,26 @@ function parseVotingDurationHours(value: unknown): number | null {
     return null;
   }
   return value;
+}
+
+function sanitizeText(input: unknown): string | null {
+  if (typeof input !== "string") return null;
+  return input.trim();
+}
+
+function canEditAmendmentContent(
+  actor: { isPrimary: boolean; isSeAdmin: boolean; id: number } | null,
+  amendment: { authorId: number; status: AmendmentStatus },
+) {
+  if (!actor) {
+    return false;
+  }
+
+  if (amendment.status !== "PRIMARY_REVIEW") {
+    return false;
+  }
+
+  return actor.isPrimary || actor.isSeAdmin || amendment.authorId === actor.id;
 }
 
 export async function GET(
@@ -230,6 +253,9 @@ export async function PATCH(
     status?: string;
     votingDurationHours?: number;
     resetVotingWindowFromNow?: boolean;
+    title?: unknown;
+    description?: unknown;
+    proposedContent?: unknown;
   };
   try {
     body = await request.json();
@@ -237,9 +263,25 @@ export async function PATCH(
     return new Response("Invalid JSON", { status: 422 });
   }
 
-  const requestedStatus = sanitizeStatus(body.status ?? null);
-  if (!requestedStatus) {
+  const requestedStatus = body.status
+    ? sanitizeStatus(body.status ?? null)
+    : null;
+  if (body.status && !requestedStatus) {
     return new Response("Invalid status value", { status: 422 });
+  }
+
+  const nextTitle = sanitizeText(body.title);
+  const nextDescription = sanitizeText(body.description);
+  const nextProposedContent = sanitizeText(body.proposedContent);
+  const wantsContentEdit =
+    nextTitle !== null ||
+    nextDescription !== null ||
+    nextProposedContent !== null;
+
+  if (!requestedStatus && !wantsContentEdit) {
+    return new Response("Provide a valid status change or amendment edits", {
+      status: 422,
+    });
   }
 
   const amendment = await prisma.amendment.findUnique({
@@ -248,6 +290,10 @@ export async function PATCH(
       id: true,
       status: true,
       authorId: true,
+      title: true,
+      description: true,
+      proposedContent: true,
+      githubPrNumber: true,
       publishedAt: true,
       votingOpenedAt: true,
     },
@@ -256,7 +302,10 @@ export async function PATCH(
     return new Response("Amendment not found", { status: 404 });
   }
 
-  if (!canChangeStatus(actor ?? null, amendment, requestedStatus)) {
+  if (
+    requestedStatus &&
+    !canChangeStatus(actor ?? null, amendment, requestedStatus)
+  ) {
     return new Response(
       "Only primary officers, SE admins, or the author may update this amendment",
       { status: 403 },
@@ -264,7 +313,45 @@ export async function PATCH(
   }
 
   const now = new Date();
-  const updateData: Record<string, unknown> = { status: requestedStatus };
+  const updateData: Record<string, unknown> = {};
+
+  if (wantsContentEdit) {
+    if (!canEditAmendmentContent(actor ?? null, amendment)) {
+      return new Response(
+        "Only the author, a primary officer, or an SE admin can edit this amendment during quorum.",
+        { status: 403 },
+      );
+    }
+
+    if (nextTitle !== null) {
+      if (!nextTitle) {
+        return new Response("title cannot be empty", { status: 422 });
+      }
+      updateData.title = nextTitle;
+    }
+
+    if (nextDescription !== null) {
+      updateData.description = nextDescription;
+    }
+
+    if (nextProposedContent !== null) {
+      if (!nextProposedContent) {
+        return new Response("proposedContent cannot be empty", { status: 422 });
+      }
+      updateData.proposedContent = nextProposedContent;
+    }
+
+    try {
+      const snapshot = await fetchConstitutionSnapshot();
+      updateData.originalContent = snapshot.content;
+    } catch {
+      // Keep the existing baseline if GitHub is unavailable while editing.
+    }
+  }
+
+  if (requestedStatus) {
+    updateData.status = requestedStatus;
+  }
 
   if (requestedStatus === "OPEN" && amendment.status !== "OPEN") {
     updateData.publishedAt = now;
@@ -321,6 +408,40 @@ export async function PATCH(
     updateData.votingOpenedAt = now;
     updateData.votingDurationHours = hours;
     updateData.votingEndsAt = new Date(now.getTime() + hours * 60 * 60 * 1000);
+
+    if (!amendment.githubPrNumber) {
+      const branchName = buildAmendmentBranchName(amendment.title, amendment.id);
+      const proposedBy = `Member #${amendment.authorId}`;
+      const prBody =
+        amendment.description ||
+        `${amendment.title}\n\nAmendment proposal by ${proposedBy}.`;
+
+      try {
+        const { prNumber, originalContent } = await createAmendmentPR({
+          title: amendment.title,
+          description: prBody,
+          proposedContent:
+            (typeof updateData.proposedContent === "string"
+              ? updateData.proposedContent
+              : amendment.proposedContent) ?? amendment.proposedContent,
+          proposedBy,
+          branchName,
+        });
+
+        updateData.githubBranch = branchName;
+        updateData.githubPrNumber = prNumber;
+        updateData.originalContent = originalContent;
+      } catch {
+        try {
+          const snapshot = await fetchConstitutionSnapshot();
+          updateData.originalContent = snapshot.content;
+        } catch {
+          // Keep the current baseline if GitHub is unavailable.
+        }
+        updateData.prCreationWarning =
+          "Member voting opened, but the GitHub PR could not be created. Use Create PR to retry.";
+      }
+    }
   }
 
   // VOTING → VOTING (edit the existing voting window without changing status)
@@ -383,10 +504,19 @@ export async function PATCH(
     updateData.votingClosedAt = now;
   }
 
+  const prCreationWarning =
+    typeof updateData.prCreationWarning === "string"
+      ? (updateData.prCreationWarning as string)
+      : null;
+  delete updateData.prCreationWarning;
+
   const updated = await prisma.amendment.update({
     where: { id: amendmentId },
     data: updateData,
   });
 
-  return Response.json(updated);
+  return Response.json({
+    ...updated,
+    prCreationWarning,
+  });
 }

--- a/next/app/api/amendments/[id]/route.ts
+++ b/next/app/api/amendments/[id]/route.ts
@@ -21,7 +21,22 @@ function sanitizeStatus(value: string | null): AmendmentStatus | null {
   return null;
 }
 
-export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+function parseVotingDurationHours(value: unknown): number | null {
+  if (
+    typeof value !== "number" ||
+    Number.isNaN(value) ||
+    value < 1 ||
+    value > 336
+  ) {
+    return null;
+  }
+  return value;
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
   const { id } = await params;
   const amendmentId = Number(id);
   if (Number.isNaN(amendmentId)) {
@@ -41,7 +56,14 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
         },
       },
       votes: {
-        select: { id: true, userId: true, approve: true, phase: true, officerPositionId: true, createdAt: true },
+        select: {
+          id: true,
+          userId: true,
+          approve: true,
+          phase: true,
+          officerPositionId: true,
+          createdAt: true,
+        },
       },
       comments: {
         select: {
@@ -67,20 +89,25 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 
   // Partition votes by phase
   const memberVotes = amendment.votes.filter((v) => v.phase === "VOTING");
-  const primaryReviewVotes = amendment.votes.filter((v) => v.phase === "PRIMARY_REVIEW");
+  const primaryReviewVotes = amendment.votes.filter(
+    (v) => v.phase === "PRIMARY_REVIEW",
+  );
 
   // Member vote summary (VOTING phase only)
   const voteSummary = computeVoteSummary(memberVotes);
   const totalActiveMembers = await getActiveMemberCount();
   const requiredVotingParticipation = Math.ceil(totalActiveMembers * (2 / 3));
   const quorumAchieved =
-    voteSummary.totalVotes >= requiredVotingParticipation || requiredVotingParticipation === 0;
+    voteSummary.totalVotes >= requiredVotingParticipation ||
+    requiredVotingParticipation === 0;
   const approvingVotesRequired = Math.ceil(voteSummary.totalVotes * (2 / 3));
-  const hasSupermajority = voteSummary.totalVotes > 0 && voteSummary.approveVotes >= approvingVotesRequired;
+  const hasSupermajority =
+    voteSummary.totalVotes > 0 &&
+    voteSummary.approveVotes >= approvingVotesRequired;
 
   // User's member vote
   const userVote = actor?.id
-    ? memberVotes.find((vote) => vote.userId === actor.id)?.approve ?? null
+    ? (memberVotes.find((vote) => vote.userId === actor.id)?.approve ?? null)
     : null;
 
   // Build position-level primary review data
@@ -98,7 +125,11 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
   });
 
   const positionSlots = allPrimaryPositions.map((pos) => {
-    const vote = primaryReviewVotes.find((v) => v.phase === "PRIMARY_REVIEW" && (v as { officerPositionId?: number }).officerPositionId === pos.id);
+    const vote = primaryReviewVotes.find(
+      (v) =>
+        v.phase === "PRIMARY_REVIEW" &&
+        (v as { officerPositionId?: number }).officerPositionId === pos.id,
+    );
     const holder = pos.officers[0]?.user ?? null;
     return {
       positionId: pos.id,
@@ -113,7 +144,8 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
   const votedCount = positionSlots.filter((s) => s.voted).length;
   const approveCount = positionSlots.filter((s) => s.approve === true).length;
   const rejectCount = positionSlots.filter((s) => s.approve === false).length;
-  const quorumRequired = totalPositions === 0 ? 0 : Math.floor(totalPositions / 2) + 1;
+  const quorumRequired =
+    totalPositions === 0 ? 0 : Math.floor(totalPositions / 2) + 1;
   const quorumMet = votedCount >= quorumRequired;
 
   return Response.json({
@@ -174,14 +206,19 @@ function canChangeStatus(
   // SE Admin can only perform the final merge (APPROVED → MERGED is handled by merge route)
   // and withdraw amendments
   if (requestedStatus === "WITHDRAWN") {
-    return actor.isPrimary || actor.isSeAdmin || amendment.authorId === actor.id;
+    return (
+      actor.isPrimary || actor.isSeAdmin || amendment.authorId === actor.id
+    );
   }
 
   // All other status transitions require primary officer
   return actor.isPrimary;
 }
 
-export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
   const { id } = await params;
   const amendmentId = Number(id);
   if (Number.isNaN(amendmentId)) {
@@ -189,7 +226,11 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
   }
 
   const actor = await getActorFromRequest(request);
-  let body: { status?: string; votingDurationHours?: number };
+  let body: {
+    status?: string;
+    votingDurationHours?: number;
+    resetVotingWindowFromNow?: boolean;
+  };
   try {
     body = await request.json();
   } catch {
@@ -203,14 +244,23 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
 
   const amendment = await prisma.amendment.findUnique({
     where: { id: amendmentId },
-    select: { id: true, status: true, authorId: true, publishedAt: true },
+    select: {
+      id: true,
+      status: true,
+      authorId: true,
+      publishedAt: true,
+      votingOpenedAt: true,
+    },
   });
   if (!amendment) {
     return new Response("Amendment not found", { status: 404 });
   }
 
   if (!canChangeStatus(actor ?? null, amendment, requestedStatus)) {
-    return new Response("Only primary officers, SE admins, or the author may update this amendment", { status: 403 });
+    return new Response(
+      "Only primary officers, SE admins, or the author may update this amendment",
+      { status: 403 },
+    );
   }
 
   const now = new Date();
@@ -221,7 +271,10 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
   }
 
   // DRAFT/OPEN → PRIMARY_REVIEW
-  if (requestedStatus === "PRIMARY_REVIEW" && amendment.status !== "PRIMARY_REVIEW") {
+  if (
+    requestedStatus === "PRIMARY_REVIEW" &&
+    amendment.status !== "PRIMARY_REVIEW"
+  ) {
     updateData.primaryReviewOpenedAt = now;
     if (!amendment.publishedAt) {
       updateData.publishedAt = now;
@@ -231,14 +284,21 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
   // PRIMARY_REVIEW → VOTING (requires position-level quorum + majority approval + voting duration)
   if (requestedStatus === "VOTING" && amendment.status === "PRIMARY_REVIEW") {
     const primaryVotes = await prisma.amendmentVote.findMany({
-      where: { amendmentId, phase: "PRIMARY_REVIEW", officerPositionId: { not: null } },
+      where: {
+        amendmentId,
+        phase: "PRIMARY_REVIEW",
+        officerPositionId: { not: null },
+      },
       select: { approve: true },
     });
-    const totalPositions = await prisma.officerPosition.count({ where: { is_primary: true } });
+    const totalPositions = await prisma.officerPosition.count({
+      where: { is_primary: true },
+    });
     const votedCount = primaryVotes.length;
     const approveCount = primaryVotes.filter((v) => v.approve).length;
     const rejectCount = votedCount - approveCount;
-    const quorumRequired = totalPositions === 0 ? 0 : Math.floor(totalPositions / 2) + 1;
+    const quorumRequired =
+      totalPositions === 0 ? 0 : Math.floor(totalPositions / 2) + 1;
     const quorumMet = votedCount >= quorumRequired;
     const majorityApproves = quorumMet && approveCount > rejectCount;
 
@@ -249,8 +309,8 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       );
     }
 
-    const hours = body.votingDurationHours;
-    if (!hours || typeof hours !== "number" || hours < 1 || hours > 336) {
+    const hours = parseVotingDurationHours(body.votingDurationHours);
+    if (hours === null) {
       return new Response(
         "votingDurationHours must be a number between 1 and 336.",
         { status: 422 },
@@ -263,17 +323,44 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
     updateData.votingEndsAt = new Date(now.getTime() + hours * 60 * 60 * 1000);
   }
 
+  // VOTING → VOTING (edit the existing voting window without changing status)
+  if (requestedStatus === "VOTING" && amendment.status === "VOTING") {
+    const hours = parseVotingDurationHours(body.votingDurationHours);
+    if (hours === null) {
+      return new Response(
+        "votingDurationHours must be a number between 1 and 336.",
+        { status: 422 },
+      );
+    }
+
+    const baseTime = body.resetVotingWindowFromNow
+      ? now
+      : (amendment.votingOpenedAt ?? now);
+    updateData.votingDurationHours = hours;
+    updateData.votingEndsAt = new Date(
+      baseTime.getTime() + hours * 60 * 60 * 1000,
+    );
+    updateData.votingClosedAt = null;
+  }
+
   // PRIMARY_REVIEW → REJECTED (requires position-level quorum + majority rejection)
   if (requestedStatus === "REJECTED" && amendment.status === "PRIMARY_REVIEW") {
     const primaryVotes = await prisma.amendmentVote.findMany({
-      where: { amendmentId, phase: "PRIMARY_REVIEW", officerPositionId: { not: null } },
+      where: {
+        amendmentId,
+        phase: "PRIMARY_REVIEW",
+        officerPositionId: { not: null },
+      },
       select: { approve: true },
     });
-    const totalPositions = await prisma.officerPosition.count({ where: { is_primary: true } });
+    const totalPositions = await prisma.officerPosition.count({
+      where: { is_primary: true },
+    });
     const votedCount = primaryVotes.length;
     const approveCount = primaryVotes.filter((v) => v.approve).length;
     const rejectCount = votedCount - approveCount;
-    const quorumRequired = totalPositions === 0 ? 0 : Math.floor(totalPositions / 2) + 1;
+    const quorumRequired =
+      totalPositions === 0 ? 0 : Math.floor(totalPositions / 2) + 1;
     const quorumMet = votedCount >= quorumRequired;
     const majorityRejects = quorumMet && rejectCount >= approveCount;
 
@@ -289,7 +376,10 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
   }
 
   // VOTING → APPROVED/REJECTED
-  if ((requestedStatus === "APPROVED" || requestedStatus === "REJECTED") && amendment.status === "VOTING") {
+  if (
+    (requestedStatus === "APPROVED" || requestedStatus === "REJECTED") &&
+    amendment.status === "VOTING"
+  ) {
     updateData.votingClosedAt = now;
   }
 

--- a/next/app/api/amendments/[id]/route.ts
+++ b/next/app/api/amendments/[id]/route.ts
@@ -41,6 +41,14 @@ function sanitizeText(input: unknown): string | null {
   return input.trim();
 }
 
+// Preserve whitespace on constitution content so edits on the detail page
+// round-trip without altering leading/trailing whitespace the user sees in
+// the DiffViewer.
+function readContent(input: unknown): string | null {
+  if (typeof input !== "string") return null;
+  return input;
+}
+
 function canEditAmendmentContent(
   actor: { isPrimary: boolean; isSeAdmin: boolean; id: number } | null,
   amendment: { authorId: number; status: AmendmentStatus },
@@ -272,7 +280,7 @@ export async function PATCH(
 
   const nextTitle = sanitizeText(body.title);
   const nextDescription = sanitizeText(body.description);
-  const nextProposedContent = sanitizeText(body.proposedContent);
+  const nextProposedContent = readContent(body.proposedContent);
   const wantsContentEdit =
     nextTitle !== null ||
     nextDescription !== null ||
@@ -335,7 +343,7 @@ export async function PATCH(
     }
 
     if (nextProposedContent !== null) {
-      if (!nextProposedContent) {
+      if (nextProposedContent.trim().length === 0) {
         return new Response("proposedContent cannot be empty", { status: 422 });
       }
       updateData.proposedContent = nextProposedContent;

--- a/next/app/api/amendments/[id]/vote/route.ts
+++ b/next/app/api/amendments/[id]/vote/route.ts
@@ -32,68 +32,148 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     return new Response('"approve" must be true or false', { status: 422 });
   }
 
-  const amendment = await prisma.amendment.findUnique({
-    where: { id: amendmentId },
-    select: {
-      id: true,
-      status: true,
-      isSemanticChange: true,
-      votingEndsAt: true,
-    },
-  });
-  if (!amendment) {
-    return new Response("Amendment not found", { status: 404 });
-  }
-
-  // Determine voting phase from amendment status
-  let phase: string;
-  if (amendment.status === AmendmentStatus.PRIMARY_REVIEW) {
-    phase = "PRIMARY_REVIEW";
-  } else if (amendment.status === AmendmentStatus.VOTING) {
-    phase = "VOTING";
-  } else {
-    return new Response("Voting is not open for this amendment", { status: 409 });
-  }
-
-  // Block voting after the voting window has ended
-  if (phase === "VOTING" && amendment.votingEndsAt && new Date(amendment.votingEndsAt) < new Date()) {
-    return new Response("The voting window has ended", { status: 409 });
-  }
-
-  // PRIMARY_REVIEW: vote per officer position
-  if (phase === "PRIMARY_REVIEW") {
-    if (!actor.isPrimary) {
-      return new Response("Only primary officers can vote during primary review", { status: 403 });
-    }
-
-    const positionId = body.officerPositionId;
-    if (!positionId || typeof positionId !== "number") {
-      return new Response("officerPositionId is required for primary review votes", { status: 422 });
-    }
-
-    // Verify the actor actually holds this primary position
-    const officerRecord = await prisma.officer.findFirst({
-      where: {
-        user_id: actor.id,
-        is_active: true,
-        position_id: positionId,
-        position: { is_primary: true },
+  try {
+    const amendment = await prisma.amendment.findUnique({
+      where: { id: amendmentId },
+      select: {
+        id: true,
+        status: true,
+        isSemanticChange: true,
+        votingEndsAt: true,
       },
-      select: { id: true },
     });
-    if (!officerRecord) {
-      return new Response("You do not hold this primary officer position", { status: 403 });
+    if (!amendment) {
+      return new Response("Amendment not found", { status: 404 });
     }
 
-    // Upsert by position (one vote per position per amendment)
-    const existing = await prisma.amendmentVote.findFirst({
-      where: { amendmentId, officerPositionId: positionId, phase: "PRIMARY_REVIEW" },
+    let phase: string;
+    if (amendment.status === AmendmentStatus.PRIMARY_REVIEW) {
+      phase = "PRIMARY_REVIEW";
+    } else if (amendment.status === AmendmentStatus.VOTING) {
+      phase = "VOTING";
+    } else {
+      return new Response("Voting is not open for this amendment", { status: 409 });
+    }
+
+    if (phase === "VOTING" && amendment.votingEndsAt && new Date(amendment.votingEndsAt) < new Date()) {
+      return new Response("The voting window has ended", { status: 409 });
+    }
+
+    if (phase === "PRIMARY_REVIEW") {
+      if (!actor.isPrimary) {
+        return new Response("Only primary officers can vote during primary review", { status: 403 });
+      }
+
+      const positionId = body.officerPositionId;
+      if (!positionId || typeof positionId !== "number") {
+        return new Response("officerPositionId is required for primary review votes", { status: 422 });
+      }
+
+      const officerRecord = await prisma.officer.findFirst({
+        where: {
+          user_id: actor.id,
+          is_active: true,
+          position_id: positionId,
+          position: { is_primary: true },
+        },
+        select: { id: true },
+      });
+      if (!officerRecord) {
+        return new Response("You do not hold this primary officer position", { status: 403 });
+      }
+
+      const existing = await prisma.amendmentVote.findFirst({
+        where: { amendmentId, officerPositionId: positionId, phase: "PRIMARY_REVIEW" },
+        select: { id: true },
+      });
+
+      if (existing) {
+        await prisma.amendmentVote.update({
+          where: { id: existing.id },
+          data: { approve: body.approve, createdAt: new Date() },
+        });
+      } else {
+        await prisma.amendmentVote.create({
+          data: {
+            amendmentId,
+            userId: actor.id,
+            approve: body.approve,
+            phase: "PRIMARY_REVIEW",
+            officerPositionId: positionId,
+          },
+        });
+      }
+
+      const allPrimaryVotes = await prisma.amendmentVote.findMany({
+        where: { amendmentId, phase: "PRIMARY_REVIEW" },
+        select: {
+          approve: true,
+          officerPositionId: true,
+          user: { select: { id: true, name: true } },
+        },
+      });
+
+      const allPrimaryPositions = await prisma.officerPosition.findMany({
+        where: { is_primary: true },
+        select: {
+          id: true,
+          title: true,
+          officers: {
+            where: { is_active: true },
+            select: { user: { select: { id: true, name: true } } },
+          },
+        },
+        orderBy: { title: "asc" },
+      });
+
+      const positionSlots = allPrimaryPositions.map((pos) => {
+        const vote = allPrimaryVotes.find((v) => v.officerPositionId === pos.id);
+        const holder = pos.officers[0]?.user ?? null;
+        return {
+          positionId: pos.id,
+          title: pos.title,
+          holder: holder ? { id: holder.id, name: holder.name } : null,
+          voted: !!vote,
+          approve: vote?.approve ?? null,
+        };
+      });
+
+      const totalPositions = positionSlots.length;
+      const votedCount = positionSlots.filter((s) => s.voted).length;
+      const approveCount = positionSlots.filter((s) => s.approve === true).length;
+      const rejectCount = positionSlots.filter((s) => s.approve === false).length;
+      const quorumRequired = totalPositions === 0 ? 0 : Math.floor(totalPositions / 2) + 1;
+      const quorumMet = votedCount >= quorumRequired;
+
+      return Response.json({
+        status: amendment.status,
+        phase: "PRIMARY_REVIEW",
+        primaryReview: {
+          positionSlots,
+          totalPositions,
+          votedCount,
+          approveCount,
+          rejectCount,
+          quorumRequired,
+          quorumMet,
+          majorityApproves: quorumMet && approveCount > rejectCount,
+          majorityRejects: quorumMet && rejectCount >= approveCount,
+        },
+      });
+    }
+
+    if (phase === "VOTING" && !amendment.isSemanticChange && !actor.isPrimary) {
+      return new Response("Only primary officers can vote on non-semantic amendments", { status: 403 });
+    }
+
+    const existingMemberVote = await prisma.amendmentVote.findFirst({
+      where: { amendmentId, userId: actor.id, phase: "VOTING" },
       select: { id: true },
     });
 
-    if (existing) {
+    if (existingMemberVote) {
       await prisma.amendmentVote.update({
-        where: { id: existing.id },
+        where: { id: existingMemberVote.id },
         data: { approve: body.approve, createdAt: new Date() },
       });
     } else {
@@ -102,124 +182,42 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
           amendmentId,
           userId: actor.id,
           approve: body.approve,
-          phase: "PRIMARY_REVIEW",
-          officerPositionId: positionId,
+          phase: "VOTING",
         },
       });
     }
 
-    // Return updated position-level vote data
-    const allPrimaryVotes = await prisma.amendmentVote.findMany({
-      where: { amendmentId, phase: "PRIMARY_REVIEW" },
-      select: {
-        approve: true,
-        officerPositionId: true,
-        user: { select: { id: true, name: true } },
-      },
+    const updatedVotes = await prisma.amendmentVote.findMany({
+      where: { amendmentId, phase: "VOTING" },
+      select: { approve: true, userId: true },
     });
 
-    const allPrimaryPositions = await prisma.officerPosition.findMany({
-      where: { is_primary: true },
-      select: {
-        id: true,
-        title: true,
-        officers: {
-          where: { is_active: true },
-          select: { user: { select: { id: true, name: true } } },
-        },
-      },
-      orderBy: { title: "asc" },
-    });
-
-    const positionSlots = allPrimaryPositions.map((pos) => {
-      const vote = allPrimaryVotes.find((v) => v.officerPositionId === pos.id);
-      const holder = pos.officers[0]?.user ?? null;
-      return {
-        positionId: pos.id,
-        title: pos.title,
-        holder: holder ? { id: holder.id, name: holder.name } : null,
-        voted: !!vote,
-        approve: vote?.approve ?? null,
-      };
-    });
-
-    const totalPositions = positionSlots.length;
-    const votedCount = positionSlots.filter((s) => s.voted).length;
-    const approveCount = positionSlots.filter((s) => s.approve === true).length;
-    const rejectCount = positionSlots.filter((s) => s.approve === false).length;
-    const quorumRequired = totalPositions === 0 ? 0 : Math.floor(totalPositions / 2) + 1;
-    const quorumMet = votedCount >= quorumRequired;
+    const voteSummary = computeVoteSummary(updatedVotes);
+    const totalActiveMembers = await getActiveMemberCount();
+    const quorum = Math.ceil(totalActiveMembers * (2 / 3));
+    const quorumMet = voteSummary.totalVotes >= quorum || quorum === 0;
+    const supermajority = Math.ceil(voteSummary.totalVotes * (2 / 3));
 
     return Response.json({
       status: amendment.status,
-      phase: "PRIMARY_REVIEW",
-      primaryReview: {
-        positionSlots,
-        totalPositions,
-        votedCount,
-        approveCount,
-        rejectCount,
-        quorumRequired,
+      phase: "VOTING",
+      voteSummary: {
+        totalVotes: voteSummary.totalVotes,
+        approveVotes: voteSummary.approveVotes,
+        rejectVotes: voteSummary.rejectVotes,
+        quorum,
         quorumMet,
-        majorityApproves: quorumMet && approveCount > rejectCount,
-        majorityRejects: quorumMet && rejectCount >= approveCount,
+        supermajority,
+        isPassed: amendment.isSemanticChange
+          ? voteSummary.totalVotes >= quorum && voteSummary.approveVotes >= supermajority
+          : !voteSummary.totalVotes ? false : voteSummary.approveVotes > voteSummary.rejectVotes,
+        hasUserVoted: true,
+        userVote: body.approve,
       },
     });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to record vote";
+    return new Response(message, { status: 500 });
   }
-
-  // VOTING phase — member vote (per-user)
-  if (phase === "VOTING" && !amendment.isSemanticChange && !actor.isPrimary) {
-    return new Response("Only primary officers can vote on non-semantic amendments", { status: 403 });
-  }
-
-  // Upsert member vote (one per user in VOTING phase)
-  const existingMemberVote = await prisma.amendmentVote.findFirst({
-    where: { amendmentId, userId: actor.id, phase: "VOTING" },
-    select: { id: true },
-  });
-
-  if (existingMemberVote) {
-    await prisma.amendmentVote.update({
-      where: { id: existingMemberVote.id },
-      data: { approve: body.approve, createdAt: new Date() },
-    });
-  } else {
-    await prisma.amendmentVote.create({
-      data: {
-        amendmentId,
-        userId: actor.id,
-        approve: body.approve,
-        phase: "VOTING",
-      },
-    });
-  }
-
-  const updatedVotes = await prisma.amendmentVote.findMany({
-    where: { amendmentId, phase: "VOTING" },
-    select: { approve: true, userId: true },
-  });
-
-  const voteSummary = computeVoteSummary(updatedVotes);
-  const totalActiveMembers = await getActiveMemberCount();
-  const quorum = Math.ceil(totalActiveMembers * (2 / 3));
-  const quorumMet = voteSummary.totalVotes >= quorum || quorum === 0;
-  const supermajority = Math.ceil(voteSummary.totalVotes * (2 / 3));
-
-  return Response.json({
-    status: amendment.status,
-    phase: "VOTING",
-    voteSummary: {
-      totalVotes: voteSummary.totalVotes,
-      approveVotes: voteSummary.approveVotes,
-      rejectVotes: voteSummary.rejectVotes,
-      quorum,
-      quorumMet,
-      supermajority,
-      isPassed: amendment.isSemanticChange
-        ? voteSummary.totalVotes >= quorum && voteSummary.approveVotes >= supermajority
-        : !voteSummary.totalVotes ? false : voteSummary.approveVotes > voteSummary.rejectVotes,
-      hasUserVoted: true,
-      userVote: body.approve,
-    },
-  });
 }

--- a/next/app/api/amendments/route.ts
+++ b/next/app/api/amendments/route.ts
@@ -1,25 +1,17 @@
 import prisma from "@/lib/prisma";
 import { AmendmentStatus } from "@prisma/client";
 import { NextRequest } from "next/server";
-import { computeVoteSummary, getActorFromRequest } from "@/lib/services/amendmentService";
 import {
+  computeVoteSummary,
+  getActorFromRequest,
+} from "@/lib/services/amendmentService";
+import {
+  buildAmendmentBranchName,
   createAmendmentPR,
   fetchConstitutionSnapshot,
 } from "@/lib/services/githubAmendmentService";
 
 export const dynamic = "force-dynamic";
-
-function buildBranchName(title: string, amendmentId: number): string {
-  const slug = title
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .replace(/-{2,}/g, "-");
-
-  const safeTitle = slug.length > 0 ? slug : "amendment";
-  return `amendment-${amendmentId}-${safeTitle}-${Date.now().toString(36)}`;
-}
 
 function sanitizeText(input: unknown): string {
   if (typeof input !== "string") return "";
@@ -31,7 +23,9 @@ export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const status = searchParams.get("status");
   const validStatus =
-    status && Object.values(AmendmentStatus).includes(status as AmendmentStatus) ? (status as AmendmentStatus) : null;
+    status && Object.values(AmendmentStatus).includes(status as AmendmentStatus)
+      ? (status as AmendmentStatus)
+      : null;
 
   const where = validStatus ? { status: validStatus } : {};
   const amendments = await prisma.amendment.findMany({
@@ -88,6 +82,7 @@ export async function POST(request: NextRequest) {
   let body: {
     title?: unknown;
     description?: unknown;
+    originalContent?: unknown;
     proposedContent?: unknown;
     isSemanticChange?: unknown;
   };
@@ -99,16 +94,19 @@ export async function POST(request: NextRequest) {
 
   const title = sanitizeText(body.title);
   const description = sanitizeText(body.description);
+  const clientOriginalContent = sanitizeText(body.originalContent);
   const proposedContent = sanitizeText(body.proposedContent);
   const isSemanticChange =
     typeof body.isSemanticChange === "boolean" ? body.isSemanticChange : true;
 
   if (!title || !proposedContent) {
-    return new Response('"title", "proposedContent" are required', { status: 422 });
+    return new Response('"title", "proposedContent" are required', {
+      status: 422,
+    });
   }
 
   // Fetch current constitution for diff — graceful if GitHub is unavailable
-  let originalContent = "";
+  let originalContent = clientOriginalContent;
   try {
     const currentSnapshot = await fetchConstitutionSnapshot();
     originalContent = currentSnapshot.content;
@@ -131,9 +129,10 @@ export async function POST(request: NextRequest) {
   });
 
   // Attempt to create a GitHub PR — non-blocking
-  const branchName = buildBranchName(title, dbDraft.id);
+  const branchName = buildAmendmentBranchName(title, dbDraft.id);
   const amendmentAuthor = `Member #${actor.id}`;
-  const prBody = description || `${title}\n\nAmendment proposal by ${amendmentAuthor}.`;
+  const prBody =
+    description || `${title}\n\nAmendment proposal by ${amendmentAuthor}.`;
   try {
     const { prNumber, originalContent: prOriginal } = await createAmendmentPR({
       title,

--- a/next/app/api/amendments/route.ts
+++ b/next/app/api/amendments/route.ts
@@ -17,6 +17,14 @@ function sanitizeText(input: unknown): string {
   return trimmed;
 }
 
+// Preserve whitespace on constitution content so the stored copy matches
+// what the wizard diffed against. Trimming caused the detail-page diff to
+// disagree with the wizard diff near the start/end of the file.
+function readContent(input: unknown): string {
+  if (typeof input !== "string") return "";
+  return input;
+}
+
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const status = searchParams.get("status");
@@ -92,12 +100,12 @@ export async function POST(request: NextRequest) {
 
   const title = sanitizeText(body.title);
   const description = sanitizeText(body.description);
-  const clientOriginalContent = sanitizeText(body.originalContent);
-  const proposedContent = sanitizeText(body.proposedContent);
+  const clientOriginalContent = readContent(body.originalContent);
+  const proposedContent = readContent(body.proposedContent);
   const isSemanticChange =
     typeof body.isSemanticChange === "boolean" ? body.isSemanticChange : true;
 
-  if (!title || !proposedContent) {
+  if (!title || proposedContent.trim().length === 0) {
     return new Response('"title", "proposedContent" are required', {
       status: 422,
     });

--- a/next/app/api/amendments/route.ts
+++ b/next/app/api/amendments/route.ts
@@ -6,8 +6,6 @@ import {
   getActorFromRequest,
 } from "@/lib/services/amendmentService";
 import {
-  buildAmendmentBranchName,
-  createAmendmentPR,
   fetchConstitutionSnapshot,
 } from "@/lib/services/githubAmendmentService";
 
@@ -114,7 +112,7 @@ export async function POST(request: NextRequest) {
     // GitHub unavailable — continue without original content
   }
 
-  const dbDraft = await prisma.amendment.create({
+  const amendment = await prisma.amendment.create({
     data: {
       title,
       description,
@@ -126,36 +124,6 @@ export async function POST(request: NextRequest) {
       publishedAt: new Date(),
       primaryReviewOpenedAt: new Date(),
     },
-  });
-
-  // Attempt to create a GitHub PR — non-blocking
-  const branchName = buildAmendmentBranchName(title, dbDraft.id);
-  const amendmentAuthor = `Member #${actor.id}`;
-  const prBody =
-    description || `${title}\n\nAmendment proposal by ${amendmentAuthor}.`;
-  try {
-    const { prNumber, originalContent: prOriginal } = await createAmendmentPR({
-      title,
-      description: prBody,
-      proposedContent,
-      proposedBy: amendmentAuthor,
-      branchName,
-    });
-
-    await prisma.amendment.update({
-      where: { id: dbDraft.id },
-      data: {
-        githubBranch: branchName,
-        githubPrNumber: prNumber,
-        originalContent: prOriginal || originalContent,
-      },
-    });
-  } catch {
-    // GitHub PR creation failed — amendment still exists without a linked PR
-  }
-
-  const amendment = await prisma.amendment.findUnique({
-    where: { id: dbDraft.id },
     select: {
       id: true,
       title: true,

--- a/next/app/api/github/webhooks/amendment-maker/route.ts
+++ b/next/app/api/github/webhooks/amendment-maker/route.ts
@@ -1,0 +1,38 @@
+import crypto from "node:crypto";
+import { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+function timingSafeEqualHex(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left, "utf8");
+  const rightBuffer = Buffer.from(right, "utf8");
+
+  if (leftBuffer.length !== rightBuffer.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.text();
+  const webhookSecret = process.env.GITHUB_WEBHOOK_SECRET?.trim();
+
+  if (webhookSecret) {
+    const signature = request.headers.get("x-hub-signature-256");
+    if (!signature) {
+      return new Response("Missing GitHub webhook signature", { status: 401 });
+    }
+
+    const expectedSignature = `sha256=${crypto
+      .createHmac("sha256", webhookSecret)
+      .update(body)
+      .digest("hex")}`;
+
+    if (!timingSafeEqualHex(signature, expectedSignature)) {
+      return new Response("Invalid GitHub webhook signature", { status: 401 });
+    }
+  }
+
+  return new Response(null, { status: 204 });
+}

--- a/next/components/amendments/AmendmentCard.tsx
+++ b/next/components/amendments/AmendmentCard.tsx
@@ -32,7 +32,10 @@ export default function AmendmentCard({
   isAuthor = false,
   muted = false,
 }: AmendmentCardProps) {
-  const hasDiff = amendment.originalContent && amendment.proposedContent &&
+  const isNewAmendment = amendment.status === "PRIMARY_REVIEW";
+  const hasDiff =
+    amendment.originalContent &&
+    amendment.proposedContent &&
     amendment.originalContent !== amendment.proposedContent;
 
   return (
@@ -40,18 +43,28 @@ export default function AmendmentCard({
       href={`/about/constitution/amendments/${amendment.id}`}
       className={`block group ${muted ? "opacity-60 hover:opacity-80" : ""}`}
     >
-      <Card depth={2} className={`transition-colors hover:bg-surface-3/30 cursor-pointer ${muted ? "p-3" : "p-4 md:p-5"}`}>
+      <Card
+        depth={2}
+        className={`cursor-pointer transition-colors hover:bg-surface-3/30 ${muted ? "p-3" : "p-4 md:p-5"}`}
+      >
         <CardHeader className="p-0">
-          <div className="flex flex-wrap gap-2 items-center justify-between">
-            <div className="flex items-center gap-3 min-w-0 flex-1">
-              <CardTitle className={`group-hover:text-primary transition-colors leading-snug ${muted ? "text-sm" : "text-base sm:text-lg"}`}>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="min-w-0 flex-1">
+              <CardTitle
+                className={`group-hover:text-primary transition-colors leading-snug ${muted ? "text-sm" : "text-base sm:text-lg"}`}
+              >
                 {amendment.title}
               </CardTitle>
-              <span className="text-sm text-muted-foreground hidden sm:inline shrink-0">
+              <span className="mt-1 block text-xs text-muted-foreground sm:text-sm">
                 by {amendment.author?.name ?? "Unknown"}
               </span>
             </div>
-            <div className="flex items-center gap-1.5 shrink-0">
+            <div className="flex w-full flex-wrap items-center gap-1.5 sm:w-auto sm:justify-end">
+              {isNewAmendment && (
+                <span className="inline-flex items-center gap-1 rounded-md bg-amber-500/12 px-2 py-0.5 text-xs font-semibold text-amber-700 dark:text-amber-300">
+                  New
+                </span>
+              )}
               {isAuthor && (
                 <span className="inline-flex items-center gap-1 rounded-md bg-primary/10 px-2 py-0.5 text-xs font-semibold text-primary">
                   <Pen className="h-2.5 w-2.5" />
@@ -59,7 +72,7 @@ export default function AmendmentCard({
                 </span>
               )}
               <AmendmentStatusBadge status={amendment.status} />
-              <ChevronRight className="h-4 w-4 text-muted-foreground/40 group-hover:text-primary/60 transition-colors" />
+              <ChevronRight className="ml-auto h-4 w-4 text-muted-foreground/40 transition-colors group-hover:text-primary/60 sm:ml-0" />
             </div>
           </div>
         </CardHeader>

--- a/next/components/amendments/AmendmentDetailClient.tsx
+++ b/next/components/amendments/AmendmentDetailClient.tsx
@@ -88,13 +88,22 @@ type AmendmentPayload = {
   comments: CommentItem[];
 };
 
+function isNewAmendment(amendment: AmendmentPayload) {
+  return (
+    amendment.status === "PRIMARY_REVIEW" &&
+    amendment.primaryReviewClosedAt === null &&
+    amendment.votingOpenedAt === null
+  );
+}
+
 export default function AmendmentDetailClient({
   amendment: initialAmendment,
 }: {
   amendment: AmendmentPayload;
 }) {
   const router = useRouter();
-  const [amendment, setAmendment] = useState<AmendmentPayload>(initialAmendment);
+  const [amendment, setAmendment] =
+    useState<AmendmentPayload>(initialAmendment);
   const [isPrimary, setIsPrimary] = useState(false);
   const [isSeAdmin, setIsSeAdmin] = useState(false);
   const [isMember, setIsMember] = useState(false);
@@ -135,7 +144,10 @@ export default function AmendmentDetailClient({
     .filter((slot) => slot.holder?.id === userId)
     .map((slot) => slot.positionId);
 
-  async function changeStatus(nextStatus: AmendmentStatus, extraData?: Record<string, unknown>) {
+  async function changeStatus(
+    nextStatus: AmendmentStatus,
+    extraData?: Record<string, unknown>,
+  ) {
     setActionMessage("");
     try {
       const response = await fetch(`/api/amendments/${amendment.id}`, {
@@ -160,9 +172,13 @@ export default function AmendmentDetailClient({
           const full = await detailResponse.json();
           setAmendment((prev) => ({ ...prev, ...full }));
         }
-      } catch { /* ignore refresh failure */ }
+      } catch {
+        /* ignore refresh failure */
+      }
     } catch (err) {
-      setActionMessage(err instanceof Error ? err.message : "Failed to update status");
+      setActionMessage(
+        err instanceof Error ? err.message : "Failed to update status",
+      );
     }
   }
 
@@ -183,7 +199,39 @@ export default function AmendmentDetailClient({
       }));
       router.refresh();
     } catch (err) {
-      setActionMessage(err instanceof Error ? err.message : "Failed to merge amendment");
+      setActionMessage(
+        err instanceof Error ? err.message : "Failed to merge amendment",
+      );
+    }
+  }
+
+  async function resubmitPr() {
+    setActionMessage("");
+    try {
+      const response = await fetch(
+        `/api/amendments/${amendment.id}/resubmit-pr`,
+        {
+          method: "POST",
+        },
+      );
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || "Failed to re-submit PR");
+      }
+
+      const refreshed = await fetch(`/api/amendments/${amendment.id}`);
+      if (!refreshed.ok) {
+        throw new Error(
+          "PR was created, but the amendment could not be refreshed",
+        );
+      }
+
+      const full = await refreshed.json();
+      setAmendment((prev) => ({ ...prev, ...full }));
+    } catch (err) {
+      setActionMessage(
+        err instanceof Error ? err.message : "Failed to re-submit PR",
+      );
     }
   }
 
@@ -191,15 +239,36 @@ export default function AmendmentDetailClient({
     return <AmendmentDetailSkeleton />;
   }
 
+  const canResubmitPr =
+    !amendment.githubPrNumber &&
+    amendment.status !== "WITHDRAWN" &&
+    amendment.status !== "MERGED" &&
+    amendment.status !== "REJECTED" &&
+    (amendment.author.id === userId || isPrimary || isSeAdmin);
+
   return (
     <section className="w-full max-w-6xl mx-auto px-2 md:px-4 space-y-5">
       {/* Breadcrumb */}
       <AmendmentBreadcrumb items={[{ label: amendment.title }]} />
 
       <NeoCard depth={1} className="p-5 md:p-7 space-y-5">
+        {isNewAmendment(amendment) && (
+          <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="inline-flex items-center gap-1 rounded-md bg-amber-500/15 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-amber-800 dark:text-amber-200">
+                New Amendment
+              </span>
+              <p className="text-sm text-amber-900/80 dark:text-amber-100/90">
+                This proposal was just introduced and is currently in primary
+                officer review before member voting opens.
+              </p>
+            </div>
+          </div>
+        )}
+
         {/* Header — no inner card, just content within the NeoCard */}
         <div className="space-y-3">
-          <div className="flex flex-wrap gap-3 justify-between items-start">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
             <div className="space-y-1.5 min-w-0 flex-1">
               <h1 className="font-display text-2xl md:text-3xl font-bold leading-tight tracking-tight">
                 {amendment.title}
@@ -211,22 +280,41 @@ export default function AmendmentDetailClient({
                 </span>
               </p>
             </div>
-            <div className="flex flex-wrap gap-2 items-center shrink-0">
+            <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto sm:justify-end">
               <AmendmentStatusBadge status={amendment.status} />
-              {(isPrimary || isSeAdmin) && amendment.status !== "WITHDRAWN" && amendment.status !== "MERGED" && amendment.status !== "REJECTED" && (
-                <ConfirmationDialog
-                  trigger={
-                    <Button size="xs" variant="ghost" className="text-muted-foreground hover:text-destructive">
-                      Withdraw
-                    </Button>
-                  }
-                  title="Withdraw Amendment"
-                  description="This will withdraw the amendment from consideration."
-                  confirmLabel="Withdraw"
-                  variant="destructive"
-                  onConfirm={() => changeStatus("WITHDRAWN" as AmendmentStatus)}
-                />
+              {canResubmitPr && (
+                <Button
+                  size="xs"
+                  variant="outline"
+                  className="w-full sm:w-auto"
+                  onClick={resubmitPr}
+                >
+                  Re-submit PR
+                </Button>
               )}
+              {(isPrimary || isSeAdmin) &&
+                amendment.status !== "WITHDRAWN" &&
+                amendment.status !== "MERGED" &&
+                amendment.status !== "REJECTED" && (
+                  <ConfirmationDialog
+                    trigger={
+                      <Button
+                        size="xs"
+                        variant="ghost"
+                        className="w-full text-muted-foreground hover:text-destructive sm:w-auto"
+                      >
+                        Withdraw
+                      </Button>
+                    }
+                    title="Withdraw Amendment"
+                    description="This will withdraw the amendment from consideration."
+                    confirmLabel="Withdraw"
+                    variant="destructive"
+                    onConfirm={() =>
+                      changeStatus("WITHDRAWN" as AmendmentStatus)
+                    }
+                  />
+                )}
               {amendment.githubPrNumber && (
                 <TooltipProvider delayDuration={200}>
                   <Tooltip>
@@ -234,7 +322,7 @@ export default function AmendmentDetailClient({
                       <Link
                         href={`https://github.com/rit-sse/governing-docs/pull/${amendment.githubPrNumber}`}
                         target="_blank"
-                        className="inline-flex items-center gap-1.5 rounded-md bg-surface-3 px-2.5 py-1 text-xs font-mono font-medium text-foreground hover:bg-surface-4 transition-colors"
+                        className="inline-flex w-full items-center justify-center gap-1.5 rounded-md bg-surface-3 px-2.5 py-1 text-xs font-mono font-medium text-foreground transition-colors hover:bg-surface-4 sm:w-auto"
                       >
                         <svg
                           className="h-3.5 w-3.5 opacity-60"
@@ -270,8 +358,14 @@ export default function AmendmentDetailClient({
             events={[
               { label: "Created", date: amendment.createdAt },
               { label: "Published", date: amendment.publishedAt },
-              { label: "Primary review opened", date: amendment.primaryReviewOpenedAt },
-              { label: "Primary review closed", date: amendment.primaryReviewClosedAt },
+              {
+                label: "Primary review opened",
+                date: amendment.primaryReviewOpenedAt,
+              },
+              {
+                label: "Primary review closed",
+                date: amendment.primaryReviewClosedAt,
+              },
               { label: "Voting opened", date: amendment.votingOpenedAt },
               { label: "Voting closed", date: amendment.votingClosedAt },
             ]}
@@ -283,7 +377,11 @@ export default function AmendmentDetailClient({
               <Tooltip>
                 <TooltipTrigger asChild>
                   <span className="inline-flex items-center gap-1 text-xs font-medium text-amber-700 dark:text-amber-400 bg-amber-500/10 rounded-md px-2 py-0.5 w-fit cursor-help">
-                    <svg className="h-3 w-3" viewBox="0 0 20 20" fill="currentColor">
+                    <svg
+                      className="h-3 w-3"
+                      viewBox="0 0 20 20"
+                      fill="currentColor"
+                    >
                       <path
                         fillRule="evenodd"
                         d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z"
@@ -304,56 +402,61 @@ export default function AmendmentDetailClient({
           )}
         </div>
 
-      {/* Main content grid */}
-      <div className="grid gap-5 lg:grid-cols-5">
-        {/* Diff viewer — takes majority of space */}
-        <Card depth={2} className="lg:col-span-3 p-4 md:p-5 order-2 lg:order-1">
-          <CardHeader className="p-0 pb-3 flex flex-row items-center justify-between">
-            <CardTitle>Patch Review</CardTitle>
-            <span className="text-xs text-muted-foreground font-mono">
-              inline diff
-            </span>
-          </CardHeader>
-          <CardContent className="p-0">
-            <DiffViewer
-              originalContent={amendment.originalContent}
-              proposedContent={amendment.proposedContent}
+        {/* Main content grid */}
+        <div className="grid gap-5 lg:grid-cols-5">
+          {/* Diff viewer — takes majority of space */}
+          <Card
+            depth={2}
+            className="lg:col-span-3 p-4 md:p-5 order-2 lg:order-1"
+          >
+            <CardHeader className="p-0 pb-3 flex flex-row items-center justify-between">
+              <CardTitle>Patch Review</CardTitle>
+              <span className="text-xs text-muted-foreground font-mono">
+                inline diff
+              </span>
+            </CardHeader>
+            <CardContent className="p-0">
+              <DiffViewer
+                originalContent={amendment.originalContent}
+                proposedContent={amendment.proposedContent}
+              />
+            </CardContent>
+          </Card>
+
+          {/* Right sidebar — VotePanel appears first on mobile */}
+          <div className="lg:col-span-2 space-y-5 order-1 lg:order-2">
+            <VotePanel
+              amendmentId={amendment.id}
+              isSemanticChange={amendment.isSemanticChange}
+              status={amendment.status}
+              totalVotes={amendment.votes.totalVotes}
+              approveVotes={amendment.votes.approveVotes}
+              rejectVotes={amendment.votes.rejectVotes}
+              requiredVotingParticipation={
+                amendment.votes.requiredVotingParticipation
+              }
+              totalActiveMembers={amendment.votes.totalActiveMembers}
+              userVote={amendment.userVote}
+              isMember={isMember}
+              isUser={isUser}
+              isPrimary={isPrimary}
+              isSeAdmin={isSeAdmin}
+              primaryReview={amendment.primaryReview}
+              votingEndsAt={amendment.votingEndsAt}
+              userPrimaryPositionIds={userPrimaryPositionIds}
+              onChangeStatus={changeStatus}
+              onMerge={merge}
+              actionMessage={actionMessage}
             />
-          </CardContent>
-        </Card>
 
-        {/* Right sidebar — VotePanel appears first on mobile */}
-        <div className="lg:col-span-2 space-y-5 order-1 lg:order-2">
-          <VotePanel
-            amendmentId={amendment.id}
-            isSemanticChange={amendment.isSemanticChange}
-            status={amendment.status}
-            totalVotes={amendment.votes.totalVotes}
-            approveVotes={amendment.votes.approveVotes}
-            rejectVotes={amendment.votes.rejectVotes}
-            requiredVotingParticipation={amendment.votes.requiredVotingParticipation}
-            totalActiveMembers={amendment.votes.totalActiveMembers}
-            userVote={amendment.userVote}
-            isMember={isMember}
-            isUser={isUser}
-            isPrimary={isPrimary}
-            isSeAdmin={isSeAdmin}
-            primaryReview={amendment.primaryReview}
-            votingEndsAt={amendment.votingEndsAt}
-            userPrimaryPositionIds={userPrimaryPositionIds}
-            onChangeStatus={changeStatus}
-            onMerge={merge}
-            actionMessage={actionMessage}
-          />
-
-          <CommentThread
-            amendmentId={amendment.id}
-            initialComments={amendment.comments}
-            canComment={isMember}
-            isUser={isUser}
-          />
+            <CommentThread
+              amendmentId={amendment.id}
+              initialComments={amendment.comments}
+              canComment={isMember}
+              isUser={isUser}
+            />
+          </div>
         </div>
-      </div>
       </NeoCard>
     </section>
   );

--- a/next/components/amendments/AmendmentDetailClient.tsx
+++ b/next/components/amendments/AmendmentDetailClient.tsx
@@ -19,6 +19,8 @@ import AmendmentBreadcrumb from "@/components/amendments/AmendmentBreadcrumb";
 import AmendmentTimeline from "@/components/amendments/AmendmentTimeline";
 import ConfirmationDialog from "@/components/amendments/ConfirmationDialog";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import AmendmentDetailSkeleton from "@/components/amendments/AmendmentDetailSkeleton";
 import { AmendmentStatus } from "@prisma/client";
 
@@ -110,8 +112,18 @@ export default function AmendmentDetailClient({
   const [isUser, setIsUser] = useState(false);
   const [roleName, setRoleName] = useState("");
   const [actionMessage, setActionMessage] = useState("");
+  const [editMessage, setEditMessage] = useState("");
   const [userId, setUserId] = useState<number | null>(null);
   const [authLoaded, setAuthLoaded] = useState(false);
+  const [isEditingDraft, setIsEditingDraft] = useState(false);
+  const [draftTitle, setDraftTitle] = useState(initialAmendment.title);
+  const [draftDescription, setDraftDescription] = useState(
+    initialAmendment.description,
+  );
+  const [draftProposedContent, setDraftProposedContent] = useState(
+    initialAmendment.proposedContent,
+  );
+  const [isSavingDraft, setIsSavingDraft] = useState(false);
 
   useEffect(() => {
     (async () => {
@@ -160,6 +172,9 @@ export default function AmendmentDetailClient({
         throw new Error(message || "Failed to update status");
       }
       const updated = await response.json();
+      if (updated?.prCreationWarning) {
+        setActionMessage(updated.prCreationWarning);
+      }
       setAmendment((prev) => ({
         ...prev,
         status: updated.status as AmendmentStatus,
@@ -205,7 +220,7 @@ export default function AmendmentDetailClient({
     }
   }
 
-  async function resubmitPr() {
+  async function createPr() {
     setActionMessage("");
     try {
       const response = await fetch(
@@ -216,7 +231,7 @@ export default function AmendmentDetailClient({
       );
       if (!response.ok) {
         const message = await response.text();
-        throw new Error(message || "Failed to re-submit PR");
+        throw new Error(message || "Failed to create PR");
       }
 
       const refreshed = await fetch(`/api/amendments/${amendment.id}`);
@@ -230,8 +245,57 @@ export default function AmendmentDetailClient({
       setAmendment((prev) => ({ ...prev, ...full }));
     } catch (err) {
       setActionMessage(
-        err instanceof Error ? err.message : "Failed to re-submit PR",
+        err instanceof Error ? err.message : "Failed to create PR",
       );
+    }
+  }
+
+  async function saveDraftEdits() {
+    setEditMessage("");
+
+    if (!draftTitle.trim()) {
+      setEditMessage("Title is required");
+      return;
+    }
+
+    if (!draftProposedContent.trim()) {
+      setEditMessage("Proposed text is required");
+      return;
+    }
+
+    setIsSavingDraft(true);
+    try {
+      const response = await fetch(`/api/amendments/${amendment.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: draftTitle,
+          description: draftDescription,
+          proposedContent: draftProposedContent,
+        }),
+      });
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || "Failed to save amendment edits");
+      }
+
+      const refreshed = await fetch(`/api/amendments/${amendment.id}`);
+      if (!refreshed.ok) {
+        throw new Error("Edits were saved, but the amendment could not be refreshed");
+      }
+
+      const full = await refreshed.json();
+      setAmendment((prev) => ({ ...prev, ...full }));
+      setDraftTitle(full.title);
+      setDraftDescription(full.description);
+      setDraftProposedContent(full.proposedContent);
+      setIsEditingDraft(false);
+    } catch (err) {
+      setEditMessage(
+        err instanceof Error ? err.message : "Failed to save amendment edits",
+      );
+    } finally {
+      setIsSavingDraft(false);
     }
   }
 
@@ -239,11 +303,13 @@ export default function AmendmentDetailClient({
     return <AmendmentDetailSkeleton />;
   }
 
-  const canResubmitPr =
+  const canEditDraft =
+    amendment.status === "PRIMARY_REVIEW" &&
+    (amendment.author.id === userId || isPrimary || isSeAdmin);
+
+  const canCreatePr =
     !amendment.githubPrNumber &&
-    amendment.status !== "WITHDRAWN" &&
-    amendment.status !== "MERGED" &&
-    amendment.status !== "REJECTED" &&
+    (amendment.status === "VOTING" || amendment.status === "APPROVED") &&
     (amendment.author.id === userId || isPrimary || isSeAdmin);
 
   return (
@@ -282,14 +348,30 @@ export default function AmendmentDetailClient({
             </div>
             <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto sm:justify-end">
               <AmendmentStatusBadge status={amendment.status} />
-              {canResubmitPr && (
+              {canEditDraft && (
                 <Button
                   size="xs"
                   variant="outline"
                   className="w-full sm:w-auto"
-                  onClick={resubmitPr}
+                  onClick={() => {
+                    setEditMessage("");
+                    setDraftTitle(amendment.title);
+                    setDraftDescription(amendment.description);
+                    setDraftProposedContent(amendment.proposedContent);
+                    setIsEditingDraft((prev) => !prev);
+                  }}
                 >
-                  Re-submit PR
+                  {isEditingDraft ? "Close Editor" : "Edit Draft Text"}
+                </Button>
+              )}
+              {canCreatePr && (
+                <Button
+                  size="xs"
+                  variant="outline"
+                  className="w-full sm:w-auto"
+                  onClick={createPr}
+                >
+                  Create PR
                 </Button>
               )}
               {(isPrimary || isSeAdmin) &&
@@ -401,6 +483,93 @@ export default function AmendmentDetailClient({
             </TooltipProvider>
           )}
         </div>
+
+        {isEditingDraft && canEditDraft && (
+          <Card depth={2} className="p-4 md:p-5 space-y-4">
+            <CardHeader className="p-0">
+              <CardTitle>Edit Quorum Draft</CardTitle>
+            </CardHeader>
+            <CardContent className="p-0 space-y-4">
+              <div className="space-y-2">
+                <label
+                  htmlFor="amendment-edit-title"
+                  className="text-sm font-medium"
+                >
+                  Title
+                </label>
+                <Input
+                  id="amendment-edit-title"
+                  value={draftTitle}
+                  onChange={(event) => setDraftTitle(event.target.value)}
+                  disabled={isSavingDraft}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label
+                  htmlFor="amendment-edit-description"
+                  className="text-sm font-medium"
+                >
+                  Description
+                </label>
+                <Textarea
+                  id="amendment-edit-description"
+                  value={draftDescription}
+                  onChange={(event) => setDraftDescription(event.target.value)}
+                  rows={3}
+                  disabled={isSavingDraft}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label
+                  htmlFor="amendment-edit-content"
+                  className="text-sm font-medium"
+                >
+                  Proposed Constitution Text
+                </label>
+                <Textarea
+                  id="amendment-edit-content"
+                  value={draftProposedContent}
+                  onChange={(event) =>
+                    setDraftProposedContent(event.target.value)
+                  }
+                  rows={16}
+                  className="font-mono text-sm"
+                  disabled={isSavingDraft}
+                />
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  size="sm"
+                  onClick={saveDraftEdits}
+                  disabled={isSavingDraft}
+                >
+                  {isSavingDraft ? "Saving..." : "Save Draft"}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => {
+                    setEditMessage("");
+                    setDraftTitle(amendment.title);
+                    setDraftDescription(amendment.description);
+                    setDraftProposedContent(amendment.proposedContent);
+                    setIsEditingDraft(false);
+                  }}
+                  disabled={isSavingDraft}
+                >
+                  Cancel
+                </Button>
+              </div>
+
+              {editMessage && (
+                <p className="text-sm text-destructive">{editMessage}</p>
+              )}
+            </CardContent>
+          </Card>
+        )}
 
         {/* Main content grid */}
         <div className="grid gap-5 lg:grid-cols-5">

--- a/next/components/amendments/AmendmentWizard.tsx
+++ b/next/components/amendments/AmendmentWizard.tsx
@@ -19,7 +19,9 @@ type AmendmentWizardProps = {
   initialContent: string;
 };
 
-export default function AmendmentWizard({ initialContent }: AmendmentWizardProps) {
+export default function AmendmentWizard({
+  initialContent,
+}: AmendmentWizardProps) {
   const router = useRouter();
   const [step, setStep] = useState(0);
   const [proposedContent, setProposedContent] = useState(initialContent);
@@ -49,6 +51,7 @@ export default function AmendmentWizard({ initialContent }: AmendmentWizardProps
           title: title.trim(),
           description: description.trim(),
           isSemanticChange,
+          originalContent: initialContent,
           proposedContent,
         }),
       });
@@ -65,7 +68,8 @@ export default function AmendmentWizard({ initialContent }: AmendmentWizardProps
       }
       router.push(`/about/constitution/amendments/${amendmentId}`);
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to submit amendment";
+      const message =
+        err instanceof Error ? err.message : "Failed to submit amendment";
       setError(message);
       setLoading(false);
     }

--- a/next/components/amendments/VotePanel.tsx
+++ b/next/components/amendments/VotePanel.tsx
@@ -19,7 +19,15 @@ import { AmendmentStatus } from "@prisma/client";
 type VotePanelProps = {
   amendmentId: number;
   isSemanticChange: boolean;
-  status: "DRAFT" | "OPEN" | "PRIMARY_REVIEW" | "VOTING" | "APPROVED" | "REJECTED" | "MERGED" | "WITHDRAWN";
+  status:
+    | "DRAFT"
+    | "OPEN"
+    | "PRIMARY_REVIEW"
+    | "VOTING"
+    | "APPROVED"
+    | "REJECTED"
+    | "MERGED"
+    | "WITHDRAWN";
   totalVotes: number;
   approveVotes: number;
   rejectVotes: number;
@@ -53,7 +61,10 @@ type VotePanelProps = {
   /** The position IDs held by the current user (for per-position voting) */
   userPrimaryPositionIds?: number[];
   /** Admin action callbacks */
-  onChangeStatus?: (s: AmendmentStatus, extraData?: Record<string, unknown>) => void;
+  onChangeStatus?: (
+    s: AmendmentStatus,
+    extraData?: Record<string, unknown>,
+  ) => void;
   onMerge?: () => void;
   actionMessage?: string;
 };
@@ -122,7 +133,8 @@ function canPassAmendment({
   totalActiveMembers: number;
 }) {
   const hasQuorum = totalVotes >= requiredVotingParticipation;
-  const hasSuperMajority = totalVotes > 0 && approveVotes >= Math.ceil((2 / 3) * totalVotes);
+  const hasSuperMajority =
+    totalVotes > 0 && approveVotes >= Math.ceil((2 / 3) * totalVotes);
 
   if (!isSemanticChange) {
     return {
@@ -160,7 +172,8 @@ function ThresholdBar({
   met: boolean;
   colorVar: string;
 }) {
-  const pct = required > 0 ? Math.min(100, Math.round((current / required) * 100)) : 100;
+  const pct =
+    required > 0 ? Math.min(100, Math.round((current / required) * 100)) : 100;
 
   return (
     <TooltipProvider delayDuration={150}>
@@ -183,7 +196,10 @@ function ThresholdBar({
             <div className="h-2 rounded-full bg-surface-3 overflow-hidden">
               <div
                 className="h-full rounded-full transition-all duration-500 ease-out"
-                style={{ width: `${pct}%`, backgroundColor: `hsl(var(${colorVar}))` }}
+                style={{
+                  width: `${pct}%`,
+                  backgroundColor: `hsl(var(${colorVar}))`,
+                }}
               />
             </div>
           </div>
@@ -210,7 +226,9 @@ function VoteLegendItem({
   tooltip?: string;
 }) {
   const inner = (
-    <div className={`flex items-center gap-2 text-sm ${tooltip ? "cursor-help" : ""}`}>
+    <div
+      className={`flex items-center gap-2 text-sm ${tooltip ? "cursor-help" : ""}`}
+    >
       <span
         className="inline-block h-3 w-3 rounded-sm shrink-0"
         style={{ backgroundColor: `hsl(var(${cssVar}))` }}
@@ -273,7 +291,17 @@ export default function VotePanel({
   });
   const [localPrimaryReview, setLocalPrimaryReview] = useState(primaryReview);
 
-  const votingWindowEnded = votingEndsAt ? new Date(votingEndsAt).getTime() < Date.now() : false;
+  const votingWindowEnded = votingEndsAt
+    ? new Date(votingEndsAt).getTime() < Date.now()
+    : false;
+  const currentVotingWindowHours = votingEndsAt
+    ? Math.max(
+        1,
+        Math.ceil(
+          (new Date(votingEndsAt).getTime() - Date.now()) / (1000 * 60 * 60),
+        ),
+      )
+    : null;
   const canVote = status === "VOTING" && !votingWindowEnded;
   const notVoted = Math.max(0, totalActiveMembers - localTotals.totalVotes);
   const totalForPct = localTotals.totalVotes || 1;
@@ -392,7 +420,9 @@ export default function VotePanel({
           {/* Position key slots */}
           <div className="space-y-2">
             {localPrimaryReview.positionSlots.map((slot) => {
-              const isMyPosition = userPrimaryPositionIds.includes(slot.positionId);
+              const isMyPosition = userPrimaryPositionIds.includes(
+                slot.positionId,
+              );
               const canActOnSlot = isMyPosition && !slot.voted;
               const hasVoted = slot.voted;
 
@@ -431,11 +461,13 @@ export default function VotePanel({
                       <p className="text-xs text-muted-foreground truncate">
                         {slot.holder?.name ?? "Vacant"}
                         {hasVoted && (
-                          <span className={`ml-1.5 font-medium ${
-                            slot.approve
-                              ? "text-emerald-600 dark:text-emerald-400"
-                              : "text-rose-600 dark:text-rose-400"
-                          }`}>
+                          <span
+                            className={`ml-1.5 font-medium ${
+                              slot.approve
+                                ? "text-emerald-600 dark:text-emerald-400"
+                                : "text-rose-600 dark:text-rose-400"
+                            }`}
+                          >
                             — {slot.approve ? "Approved" : "Rejected"}
                           </span>
                         )}
@@ -446,11 +478,13 @@ export default function VotePanel({
                     {isMyPosition && (
                       <div className="flex gap-1.5 shrink-0">
                         {hasVoted ? (
-                          <span className={`text-xs font-semibold px-2 py-1 rounded ${
-                            slot.approve
-                              ? "text-emerald-700 dark:text-emerald-300"
-                              : "text-rose-700 dark:text-rose-300"
-                          }`}>
+                          <span
+                            className={`text-xs font-semibold px-2 py-1 rounded ${
+                              slot.approve
+                                ? "text-emerald-700 dark:text-emerald-300"
+                                : "text-rose-700 dark:text-rose-300"
+                            }`}
+                          >
                             {slot.approve ? "Approved" : "Rejected"}
                           </span>
                         ) : (
@@ -460,7 +494,9 @@ export default function VotePanel({
                               variant="outline"
                               disabled={submitting}
                               className="text-emerald-700 dark:text-emerald-300 border-emerald-500/30 hover:bg-emerald-500/10 h-7 px-2"
-                              onClick={() => castPositionVote(slot.positionId, true)}
+                              onClick={() =>
+                                castPositionVote(slot.positionId, true)
+                              }
                             >
                               Approve
                             </Button>
@@ -469,7 +505,9 @@ export default function VotePanel({
                               variant="outline"
                               disabled={submitting}
                               className="text-rose-700 dark:text-rose-300 border-rose-500/30 hover:bg-rose-500/10 h-7 px-2"
-                              onClick={() => castPositionVote(slot.positionId, false)}
+                              onClick={() =>
+                                castPositionVote(slot.positionId, false)
+                              }
                             >
                               Reject
                             </Button>
@@ -505,10 +543,14 @@ export default function VotePanel({
               rejected
             </span>
             <span className="ml-auto">
-              <span className="tabular-nums">{localPrimaryReview.votedCount}</span>
+              <span className="tabular-nums">
+                {localPrimaryReview.votedCount}
+              </span>
               {" / "}
-              <span className="tabular-nums">{localPrimaryReview.totalPositions}</span>
-              {" "}voted
+              <span className="tabular-nums">
+                {localPrimaryReview.totalPositions}
+              </span>{" "}
+              voted
             </span>
           </div>
         </div>
@@ -517,28 +559,34 @@ export default function VotePanel({
       {/* Non-semantic info banner */}
       {status !== "PRIMARY_REVIEW" && !isSemanticChange && canVote && (
         <div className="rounded-lg bg-sky-500/8 border border-sky-500/20 px-3 py-2 text-xs text-sky-700 dark:text-sky-300">
-          Non-semantic changes require primary officer consensus. Only primary officers vote on this type.
+          Non-semantic changes require primary officer consensus. Only primary
+          officers vote on this type.
         </div>
       )}
 
       {/* Voting countdown */}
-      {canVote && votingEndsAt && (() => {
-        const remaining = new Date(votingEndsAt).getTime() - Date.now();
-        if (remaining <= 0) {
+      {canVote &&
+        votingEndsAt &&
+        (() => {
+          const remaining = new Date(votingEndsAt).getTime() - Date.now();
+          if (remaining <= 0) {
+            return (
+              <div className="rounded-lg bg-rose-500/10 border border-rose-500/20 px-3 py-2 text-xs text-rose-700 dark:text-rose-300 font-medium">
+                Voting window has ended
+              </div>
+            );
+          }
+          const days = Math.floor(remaining / (1000 * 60 * 60 * 24));
+          const hours = Math.floor(
+            (remaining % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60),
+          );
           return (
-            <div className="rounded-lg bg-rose-500/10 border border-rose-500/20 px-3 py-2 text-xs text-rose-700 dark:text-rose-300 font-medium">
-              Voting window has ended
+            <div className="rounded-lg bg-amber-500/10 border border-amber-500/20 px-3 py-2 text-xs text-amber-700 dark:text-amber-300 font-medium">
+              {days > 0 ? `${days} day${days !== 1 ? "s" : ""}, ` : ""}
+              {hours} hour{hours !== 1 ? "s" : ""} remaining
             </div>
           );
-        }
-        const days = Math.floor(remaining / (1000 * 60 * 60 * 24));
-        const hours = Math.floor((remaining % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
-        return (
-          <div className="rounded-lg bg-amber-500/10 border border-amber-500/20 px-3 py-2 text-xs text-amber-700 dark:text-amber-300 font-medium">
-            {days > 0 ? `${days} day${days !== 1 ? "s" : ""}, ` : ""}{hours} hour{hours !== 1 ? "s" : ""} remaining
-          </div>
-        );
-      })()}
+        })()}
 
       {/* Pie chart + legend */}
       {status !== "PRIMARY_REVIEW" && (
@@ -629,7 +677,11 @@ export default function VotePanel({
                       </Button>
                     </TooltipTrigger>
                     <TooltipContent>
-                      <p>{localUserVote === true ? "You approved this amendment. Click to re-confirm." : "Vote to approve this amendment"}</p>
+                      <p>
+                        {localUserVote === true
+                          ? "You approved this amendment. Click to re-confirm."
+                          : "Vote to approve this amendment"}
+                      </p>
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
@@ -638,14 +690,20 @@ export default function VotePanel({
                     <TooltipTrigger asChild>
                       <Button
                         disabled={submitting}
-                        variant={localUserVote === false ? "destructive" : "outline"}
+                        variant={
+                          localUserVote === false ? "destructive" : "outline"
+                        }
                         onClick={() => castVote(false)}
                       >
                         {localUserVote === false ? "Rejected" : "Reject"}
                       </Button>
                     </TooltipTrigger>
                     <TooltipContent>
-                      <p>{localUserVote === false ? "You rejected this amendment. Click to re-confirm." : "Vote to reject this amendment"}</p>
+                      <p>
+                        {localUserVote === false
+                          ? "You rejected this amendment. Click to re-confirm."
+                          : "Vote to reject this amendment"}
+                      </p>
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
@@ -691,7 +749,9 @@ export default function VotePanel({
       )}
 
       {/* Outcome badge for closed votes */}
-      {(status === "APPROVED" || status === "REJECTED" || status === "MERGED") && (
+      {(status === "APPROVED" ||
+        status === "REJECTED" ||
+        status === "MERGED") && (
         <div
           className={`rounded-lg px-4 py-3 text-sm font-medium ${
             status === "REJECTED"
@@ -716,48 +776,92 @@ export default function VotePanel({
               {localPrimaryReview.majorityApproves && (
                 <VotingDurationDialog
                   trigger={
-                    <Button size="sm" className="w-full">Open Member Voting</Button>
+                    <Button size="sm" className="w-full">
+                      Open Member Voting
+                    </Button>
                   }
-                  onConfirm={(hours) => onChangeStatus("VOTING" as AmendmentStatus, { votingDurationHours: hours })}
+                  onConfirm={(hours) =>
+                    onChangeStatus("VOTING" as AmendmentStatus, {
+                      votingDurationHours: hours,
+                    })
+                  }
                 />
               )}
               {localPrimaryReview.majorityRejects && (
                 <ConfirmationDialog
                   trigger={
-                    <Button size="sm" variant="destructive" className="w-full">Close as Rejected</Button>
+                    <Button size="sm" variant="destructive" className="w-full">
+                      Close as Rejected
+                    </Button>
                   }
                   title="Reject Amendment"
                   description="Primary officers have rejected this amendment."
                   confirmLabel="Reject"
                   variant="destructive"
-                  onConfirm={() => onChangeStatus("REJECTED" as AmendmentStatus)}
+                  onConfirm={() =>
+                    onChangeStatus("REJECTED" as AmendmentStatus)
+                  }
                 />
               )}
             </div>
           )}
 
-          {/* VOTING: approve or reject (after window ends) */}
-          {status === "VOTING" && isPrimary && votingWindowEnded && (
-            <div className="flex gap-2 pt-1 border-t border-border/40">
-              <ConfirmationDialog
+          {/* VOTING: edit the window, then approve or reject once it closes */}
+          {status === "VOTING" && isPrimary && (
+            <div className="space-y-2 pt-1 border-t border-border/40">
+              <VotingDurationDialog
                 trigger={
-                  <Button size="sm" className="flex-1">Approve</Button>
+                  <Button size="sm" variant="outline" className="w-full">
+                    Edit Voting Window
+                  </Button>
                 }
-                title="Approve Amendment"
-                description="This will approve the amendment and close voting."
-                confirmLabel="Approve"
-                onConfirm={() => onChangeStatus("APPROVED" as AmendmentStatus)}
-              />
-              <ConfirmationDialog
-                trigger={
-                  <Button size="sm" variant="destructive" className="flex-1">Reject</Button>
+                title="Edit Voting Window"
+                description="Update how much longer member voting should remain open. The new duration is applied from now."
+                confirmLabel="Save Voting Window"
+                defaultHours={currentVotingWindowHours}
+                onConfirm={(hours) =>
+                  onChangeStatus("VOTING" as AmendmentStatus, {
+                    votingDurationHours: hours,
+                    resetVotingWindowFromNow: true,
+                  })
                 }
-                title="Reject Amendment"
-                description="This will reject the amendment."
-                confirmLabel="Reject"
-                variant="destructive"
-                onConfirm={() => onChangeStatus("REJECTED" as AmendmentStatus)}
               />
+
+              {votingWindowEnded && (
+                <div className="flex gap-2">
+                  <ConfirmationDialog
+                    trigger={
+                      <Button size="sm" className="flex-1">
+                        Approve
+                      </Button>
+                    }
+                    title="Approve Amendment"
+                    description="This will approve the amendment and close voting."
+                    confirmLabel="Approve"
+                    onConfirm={() =>
+                      onChangeStatus("APPROVED" as AmendmentStatus)
+                    }
+                  />
+                  <ConfirmationDialog
+                    trigger={
+                      <Button
+                        size="sm"
+                        variant="destructive"
+                        className="flex-1"
+                      >
+                        Reject
+                      </Button>
+                    }
+                    title="Reject Amendment"
+                    description="This will reject the amendment."
+                    confirmLabel="Reject"
+                    variant="destructive"
+                    onConfirm={() =>
+                      onChangeStatus("REJECTED" as AmendmentStatus)
+                    }
+                  />
+                </div>
+              )}
             </div>
           )}
 
@@ -766,7 +870,9 @@ export default function VotePanel({
             <div className="pt-1 border-t border-border/40">
               <ConfirmationDialog
                 trigger={
-                  <Button size="sm" className="w-full">Merge into Constitution</Button>
+                  <Button size="sm" className="w-full">
+                    Merge into Constitution
+                  </Button>
                 }
                 title="Merge Pull Request"
                 description="This will merge the amendment into the governing documents."

--- a/next/components/amendments/VotePanel.tsx
+++ b/next/components/amendments/VotePanel.tsx
@@ -409,9 +409,10 @@ export default function VotePanel({
         payload !== null &&
         payload.primaryReview
       ) {
-        setLocalPrimaryReview(
-          payload.primaryReview as VotePanelProps["primaryReview"],
-        );
+        const nextPrimaryReview = payload.primaryReview as NonNullable<
+          VotePanelProps["primaryReview"]
+        >;
+        setLocalPrimaryReview(nextPrimaryReview);
       }
     } catch (err) {
       alert(err instanceof Error ? err.message : "Could not record vote");

--- a/next/components/amendments/VotePanel.tsx
+++ b/next/components/amendments/VotePanel.tsx
@@ -332,6 +332,19 @@ export default function VotePanel({
 
   const requiredApproveVotes = Math.ceil((2 / 3) * localTotals.totalVotes);
 
+  async function readResponsePayload(response: Response) {
+    const raw = await response.text();
+    if (!raw) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      return raw;
+    }
+  }
+
   async function castVote(approve: boolean) {
     setSubmitting(true);
     try {
@@ -340,16 +353,30 @@ export default function VotePanel({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ approve }),
       });
-      const payload = await response.json();
+      const payload = await readResponsePayload(response);
       if (!response.ok) {
-        throw new Error(payload?.error ?? payload ?? "Could not record vote");
+        throw new Error(
+          typeof payload === "object" && payload !== null
+            ? ((payload.error as string | undefined) ??
+              (payload.message as string | undefined) ??
+              "Could not record vote")
+            : ((payload as string | null) ?? "Could not record vote"),
+        );
       }
+      const voteSummary =
+        typeof payload === "object" && payload !== null
+          ? (payload.voteSummary as
+              | {
+                  totalVotes?: number;
+                  approveVotes?: number;
+                  rejectVotes?: number;
+                }
+              | undefined)
+          : undefined;
       setLocalTotals({
-        totalVotes: payload?.voteSummary?.totalVotes ?? localTotals.totalVotes,
-        approveVotes:
-          payload?.voteSummary?.approveVotes ?? localTotals.approveVotes,
-        rejectVotes:
-          payload?.voteSummary?.rejectVotes ?? localTotals.rejectVotes,
+        totalVotes: voteSummary?.totalVotes ?? localTotals.totalVotes,
+        approveVotes: voteSummary?.approveVotes ?? localTotals.approveVotes,
+        rejectVotes: voteSummary?.rejectVotes ?? localTotals.rejectVotes,
       });
       setLocalUserVote(approve);
     } catch (err) {
@@ -367,12 +394,24 @@ export default function VotePanel({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ approve, officerPositionId: positionId }),
       });
-      const payload = await response.json();
+      const payload = await readResponsePayload(response);
       if (!response.ok) {
-        throw new Error(payload?.error ?? payload ?? "Could not record vote");
+        throw new Error(
+          typeof payload === "object" && payload !== null
+            ? ((payload.error as string | undefined) ??
+              (payload.message as string | undefined) ??
+              "Could not record vote")
+            : ((payload as string | null) ?? "Could not record vote"),
+        );
       }
-      if (payload.primaryReview) {
-        setLocalPrimaryReview(payload.primaryReview);
+      if (
+        typeof payload === "object" &&
+        payload !== null &&
+        payload.primaryReview
+      ) {
+        setLocalPrimaryReview(
+          payload.primaryReview as VotePanelProps["primaryReview"],
+        );
       }
     } catch (err) {
       alert(err instanceof Error ? err.message : "Could not record vote");

--- a/next/components/amendments/VotingDurationDialog.tsx
+++ b/next/components/amendments/VotingDurationDialog.tsx
@@ -18,6 +18,10 @@ import { Clock } from "lucide-react";
 type VotingDurationDialogProps = {
   trigger: React.ReactNode;
   onConfirm: (durationHours: number) => void | Promise<void>;
+  title?: string;
+  description?: string;
+  confirmLabel?: string;
+  defaultHours?: number | null;
 };
 
 const PRESETS = [
@@ -30,17 +34,38 @@ const PRESETS = [
 export default function VotingDurationDialog({
   trigger,
   onConfirm,
+  title = "Open Member Voting",
+  description = "Primary officers have approved this amendment. Choose how long the voting window should be open. Voting starts immediately.",
+  confirmLabel = "Start Voting Now",
+  defaultHours = 168,
 }: VotingDurationDialogProps) {
   const [open, setOpen] = useState(false);
-  const [selectedPreset, setSelectedPreset] = useState<number | null>(168);
-  const [useCustom, setUseCustom] = useState(false);
-  const [days, setDays] = useState("");
-  const [hours, setHours] = useState("");
+  const normalizedDefaultHours = defaultHours ?? 168;
+  const defaultPreset = PRESETS.some(
+    (preset) => preset.hours === normalizedDefaultHours,
+  )
+    ? normalizedDefaultHours
+    : 168;
+  const [selectedPreset, setSelectedPreset] = useState<number | null>(
+    defaultPreset,
+  );
+  const [useCustom, setUseCustom] = useState(
+    defaultHours !== null &&
+      !PRESETS.some((preset) => preset.hours === normalizedDefaultHours),
+  );
+  const [days, setDays] = useState(
+    useCustom ? String(Math.floor(normalizedDefaultHours / 24)) : "",
+  );
+  const [hours, setHours] = useState(
+    useCustom ? String(Math.floor(normalizedDefaultHours % 24)) : "",
+  );
   const [minutes, setMinutes] = useState("");
   const [loading, setLoading] = useState(false);
 
   const customTotalHours =
-    (parseInt(days) || 0) * 24 + (parseInt(hours) || 0) + (parseInt(minutes) || 0) / 60;
+    (parseInt(days) || 0) * 24 +
+    (parseInt(hours) || 0) +
+    (parseInt(minutes) || 0) / 60;
   const effectiveHours = useCustom ? customTotalHours : (selectedPreset ?? 0);
   const isValid = effectiveHours >= 0.5 && effectiveHours <= 336;
 
@@ -75,12 +100,9 @@ export default function VotingDurationDialog({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Clock className="h-5 w-5 text-primary/60" />
-            Open Member Voting
+            {title}
           </DialogTitle>
-          <DialogDescription>
-            Primary officers have approved this amendment. Choose how long the
-            voting window should be open. Voting starts immediately.
-          </DialogDescription>
+          <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4 py-2">
@@ -116,10 +138,14 @@ export default function VotingDurationDialog({
               type="button"
               onClick={() => setUseCustom(!useCustom)}
               className={`text-sm font-medium transition-colors ${
-                useCustom ? "text-primary" : "text-muted-foreground hover:text-foreground"
+                useCustom
+                  ? "text-primary"
+                  : "text-muted-foreground hover:text-foreground"
               }`}
             >
-              {useCustom ? "Using custom duration" : "Or set a custom duration..."}
+              {useCustom
+                ? "Using custom duration"
+                : "Or set a custom duration..."}
             </button>
             {useCustom && (
               <div className="flex items-center gap-2">
@@ -169,18 +195,22 @@ export default function VotingDurationDialog({
               Voting will be open for{" "}
               <span className="font-semibold text-foreground">
                 {formatDuration(effectiveHours)}
-              </span>
-              {" "}and starts immediately upon confirmation.
+              </span>{" "}
+              and starts immediately upon confirmation.
             </div>
           )}
         </div>
 
         <DialogFooter>
-          <Button variant="neutral" onClick={() => setOpen(false)} disabled={loading}>
+          <Button
+            variant="neutral"
+            onClick={() => setOpen(false)}
+            disabled={loading}
+          >
             Cancel
           </Button>
           <Button onClick={handleConfirm} disabled={loading || !isValid}>
-            {loading ? "Starting vote..." : "Start Voting Now"}
+            {loading ? "Saving..." : confirmLabel}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/next/lib/services/githubAmendmentService.ts
+++ b/next/lib/services/githubAmendmentService.ts
@@ -108,6 +108,11 @@ function createGithubAppJwt(): string {
   }
 
   const now = Math.floor(Date.now() / 1000);
+  // NOTE: do NOT pass `noTimestamp: true` here. jsonwebtoken deletes the `iat`
+  // claim from the payload when that option is set (see node_modules/
+  // jsonwebtoken/sign.js), even if we set it manually. GitHub rejects the
+  // JWT assertion with "Missing 'issued at' claim ('iat')" when that happens.
+  // With `noTimestamp` unset, the library preserves our manual `iat` value.
   return jwt.sign(
     {
       iat: now - 60,
@@ -117,7 +122,6 @@ function createGithubAppJwt(): string {
     config.privateKey,
     {
       algorithm: "RS256",
-      noTimestamp: true,
     },
   );
 }

--- a/next/lib/services/githubAmendmentService.ts
+++ b/next/lib/services/githubAmendmentService.ts
@@ -1,8 +1,12 @@
+import jwt from "jsonwebtoken";
+
 const GOVERNING_DOC_OWNER = "rit-sse";
 const GOVERNING_DOC_REPO = "governing-docs";
 const GOVERNING_DOC_BRANCH = "main";
 const GOVERNING_DOC_PATH = "constitution.md";
 const GOVERNING_DOCS_API = `https://api.github.com/repos/${GOVERNING_DOC_OWNER}/${GOVERNING_DOC_REPO}`;
+const GITHUB_API_VERSION = "2022-11-28";
+const GITHUB_INSTALLATION_TOKEN_BUFFER_MS = 60_000;
 
 type GitHubFileResponse = {
   content: string;
@@ -24,6 +28,15 @@ type GitHubPullRequest = {
   mergeable: boolean | null;
 };
 
+type GitHubInstallation = {
+  id: number;
+};
+
+type GitHubInstallationToken = {
+  token: string;
+  expires_at: string;
+};
+
 export type ConstitutionFileSnapshot = {
   content: string;
   sha: string;
@@ -36,18 +49,206 @@ export type AmendmentPRResult = {
   originalContent: string;
 };
 
-function getGithubToken(): string {
-  const token = process.env.GITHUB_PAT;
+export function buildAmendmentBranchName(
+  title: string,
+  amendmentId: number,
+): string {
+  const slug = title
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+
+  const safeTitle = slug.length > 0 ? slug : "amendment";
+  return `amendment-${amendmentId}-${safeTitle}-${Date.now().toString(36)}`;
+}
+
+function normalizeGithubPrivateKey(privateKey: string): string {
+  return privateKey.replace(/\\n/g, "\n").trim();
+}
+
+function getLegacyGithubToken(): string | null {
+  const token = process.env.GITHUB_PAT?.trim();
+  return token && token.length > 0 ? token : null;
+}
+
+function getGithubAppConfig():
+  | {
+      appId: string;
+      installationId: number | null;
+      privateKey: string;
+    }
+  | null {
+  const appId = process.env.GITHUB_APP_ID?.trim();
+  const privateKey = process.env.GITHUB_APP_PRIVATE_KEY?.trim();
+
+  if (!appId || !privateKey) {
+    return null;
+  }
+
+  const installationIdValue = process.env.GITHUB_APP_INSTALLATION_ID?.trim();
+  const installationId = installationIdValue ? Number(installationIdValue) : null;
+
+  if (installationIdValue && Number.isNaN(installationId)) {
+    throw new Error("GITHUB_APP_INSTALLATION_ID must be a number when provided.");
+  }
+
+  return {
+    appId,
+    installationId,
+    privateKey: normalizeGithubPrivateKey(privateKey),
+  };
+}
+
+function createGithubAppJwt(): string {
+  const config = getGithubAppConfig();
+  if (!config) {
+    throw new Error("GitHub App credentials are not configured on the server.");
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  return jwt.sign(
+    {
+      iat: now - 60,
+      exp: now + 9 * 60,
+      iss: config.appId,
+    },
+    config.privateKey,
+    {
+      algorithm: "RS256",
+      noTimestamp: true,
+    },
+  );
+}
+
+let cachedInstallationToken:
+  | {
+      token: string;
+      expiresAtMs: number;
+    }
+  | null = null;
+let cachedInstallationTokenPromise: Promise<string> | null = null;
+let cachedInstallationId: number | null = null;
+
+async function fetchGithubWithJwt(url: string, options: RequestInit = {}) {
+  const headers = new Headers(options.headers);
+  headers.set("Authorization", `Bearer ${createGithubAppJwt()}`);
+  headers.set("X-GitHub-Api-Version", GITHUB_API_VERSION);
+  headers.set("User-Agent", "sse-amendment-feature");
+
+  if (!headers.has("Accept")) {
+    headers.set("Accept", "application/vnd.github+json");
+  }
+  if (options.body && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  const response = await fetch(url, {
+    ...options,
+    headers,
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(
+      `GitHub App request failed (${response.status}): ${message}`,
+    );
+  }
+
+  return response;
+}
+
+async function resolveGithubInstallationId(): Promise<number> {
+  const config = getGithubAppConfig();
+  if (!config) {
+    throw new Error("GitHub App credentials are not configured on the server.");
+  }
+
+  if (config.installationId) {
+    cachedInstallationId = config.installationId;
+    return config.installationId;
+  }
+
+  if (cachedInstallationId) {
+    return cachedInstallationId;
+  }
+
+  const response = await fetchGithubWithJwt(
+    `${GOVERNING_DOCS_API}/installation`,
+    {
+      method: "GET",
+    },
+  );
+  const installation = (await response.json()) as GitHubInstallation;
+
+  if (!installation?.id) {
+    throw new Error(
+      `GitHub App is not installed on ${GOVERNING_DOC_OWNER}/${GOVERNING_DOC_REPO}.`,
+    );
+  }
+
+  cachedInstallationId = installation.id;
+  return installation.id;
+}
+
+async function getGithubInstallationToken(): Promise<string> {
+  if (
+    cachedInstallationToken &&
+    cachedInstallationToken.expiresAtMs - GITHUB_INSTALLATION_TOKEN_BUFFER_MS >
+      Date.now()
+  ) {
+    return cachedInstallationToken.token;
+  }
+
+  if (!cachedInstallationTokenPromise) {
+    cachedInstallationTokenPromise = (async () => {
+      const installationId = await resolveGithubInstallationId();
+      const response = await fetchGithubWithJwt(
+        `https://api.github.com/app/installations/${installationId}/access_tokens`,
+        {
+          method: "POST",
+        },
+      );
+      const token = (await response.json()) as GitHubInstallationToken;
+      const expiresAtMs = Date.parse(token.expires_at);
+
+      if (!token.token || Number.isNaN(expiresAtMs)) {
+        throw new Error("GitHub App did not return a valid installation token.");
+      }
+
+      cachedInstallationToken = {
+        token: token.token,
+        expiresAtMs,
+      };
+
+      return token.token;
+    })().finally(() => {
+      cachedInstallationTokenPromise = null;
+    });
+  }
+
+  return cachedInstallationTokenPromise;
+}
+
+async function getGithubToken(): Promise<string> {
+  if (getGithubAppConfig()) {
+    return getGithubInstallationToken();
+  }
+
+  const token = getLegacyGithubToken();
   if (!token) {
-    throw new Error("GITHUB_PAT is not configured on the server.");
+    throw new Error(
+      "Neither GitHub App credentials nor GITHUB_PAT are configured on the server.",
+    );
   }
   return token;
 }
 
 async function fetchGithub(url: string, options: RequestInit = {}) {
   const headers = new Headers(options.headers);
-  headers.set("Authorization", `Bearer ${getGithubToken()}`);
-  headers.set("X-GitHub-Api-Version", "2022-11-28");
+  headers.set("Authorization", `Bearer ${await getGithubToken()}`);
+  headers.set("X-GitHub-Api-Version", GITHUB_API_VERSION);
   headers.set("User-Agent", "sse-amendment-feature");
 
   if (!headers.has("Accept")) {
@@ -63,7 +264,9 @@ async function fetchGithub(url: string, options: RequestInit = {}) {
   });
   if (!response.ok) {
     const message = await response.text();
-    throw new Error(`GitHub API request failed (${response.status}): ${message}`);
+    throw new Error(
+      `GitHub API request failed (${response.status}): ${message}`,
+    );
   }
   return response;
 }
@@ -92,7 +295,9 @@ export async function fetchConstitutionSnapshot(): Promise<ConstitutionFileSnaps
   );
   const json = (await response.json()) as GitHubFileResponse;
   if (!json?.content || !json?.sha) {
-    throw new Error("GitHub API did not return a valid constitution file payload.");
+    throw new Error(
+      "GitHub API did not return a valid constitution file payload.",
+    );
   }
 
   const content = decodeBase64File(json.content.replace(/\n/g, ""));
@@ -103,9 +308,12 @@ export async function fetchConstitutionSnapshot(): Promise<ConstitutionFileSnaps
 }
 
 async function createAmendmentBranch(branchName: string): Promise<void> {
-  const baseRefResponse = await fetchGithub(`${GOVERNING_DOCS_API}/git/ref/heads/${GOVERNING_DOC_BRANCH}`, {
-    method: "GET",
-  });
+  const baseRefResponse = await fetchGithub(
+    `${GOVERNING_DOCS_API}/git/ref/heads/${GOVERNING_DOC_BRANCH}`,
+    {
+      method: "GET",
+    },
+  );
   const baseRef = (await baseRefResponse.json()) as GitHubRefResponse;
 
   await fetchGithub(`${GOVERNING_DOCS_API}/git/refs`, {
@@ -144,7 +352,8 @@ export async function createAmendmentPR(params: {
   proposedBy: string;
   branchName: string;
 }): Promise<AmendmentPRResult> {
-  const { title, description, proposedContent, proposedBy, branchName } = params;
+  const { title, description, proposedContent, proposedBy, branchName } =
+    params;
   const snapshot = await fetchConstitutionSnapshot();
   await createAmendmentBranch(branchName);
   await commitConstitutionToBranch({
@@ -179,12 +388,15 @@ export async function createAmendmentPR(params: {
 }
 
 export async function fetchPRDiff(prNumber: number): Promise<string> {
-  const response = await fetchGithub(`${GOVERNING_DOCS_API}/pulls/${prNumber}.diff`, {
-    method: "GET",
-    headers: {
-      Accept: "application/vnd.github.v3.diff",
+  const response = await fetchGithub(
+    `${GOVERNING_DOCS_API}/pulls/${prNumber}.diff`,
+    {
+      method: "GET",
+      headers: {
+        Accept: "application/vnd.github.v3.diff",
+      },
     },
-  });
+  );
 
   return response.text();
 }

--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -58,7 +58,7 @@
         "react-easy-crop": "^5.5.6",
         "react-is": "^19.2.4",
         "react-markdown": "^9.0.1",
-        "recharts": "^3.7.0",
+        "recharts": "^3.8.1",
         "rehype-sanitize": "^6.0.0",
         "rehype-stringify": "^10.0.0",
         "remark": "^15.0.1",
@@ -14148,15 +14148,15 @@
       }
     },
     "node_modules/recharts": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.7.0.tgz",
-      "integrity": "sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
       "license": "MIT",
       "workspaces": [
         "www"
       ],
       "dependencies": {
-        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
         "clsx": "^2.1.1",
         "decimal.js-light": "^2.5.1",
         "es-toolkit": "^1.39.3",

--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -78,7 +78,7 @@
         "@tailwindcss/forms": "^0.5.6",
         "@tailwindcss/typography": "^0.5.10",
         "@types/jsonwebtoken": "^9.0.7",
-        "@types/node": "^20.8.9",
+        "@types/node": "^25.5.2",
         "@types/nodemailer": "^7.0.5",
         "@vitest/coverage-v8": "^4.0.18",
         "cross-env": "^10.0.0",
@@ -6951,12 +6951,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.33",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
-      "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
+      "version": "25.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/nodemailer": {
@@ -15756,9 +15756,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -84,7 +84,7 @@
         "cross-env": "^10.0.0",
         "eslint-plugin-react-hooks": "^7.0.1",
         "husky": "^9.1.7",
-        "knip": "^5.39.0",
+        "knip": "^6.3.1",
         "lint-staged": "^15.2.10",
         "prettier": "^3.8.1",
         "prisma": "5.22.0",
@@ -2789,6 +2789,375 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.121.0.tgz",
+      "integrity": "sha512-n07FQcySwOlzap424/PLMtOkbS7xOu8nsJduKL8P3COGHKgKoDYXwoAHCbChfgFpHnviehrLWIPX0lKGtbEk/A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.121.0.tgz",
+      "integrity": "sha512-/Dd1xIXboYAicw+twT2utxPD7bL8qh7d3ej0qvaYIMj3/EgIrGR+tSnjCUkiCT6g6uTC0neSS4JY8LxhdSU/sA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.121.0.tgz",
+      "integrity": "sha512-A0jNEvv7QMtCO1yk205t3DWU9sWUjQ2KNF0hSVO5W9R9r/R1BIvzG01UQAfmtC0dQm7sCrs5puixurKSfr2bRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.121.0.tgz",
+      "integrity": "sha512-SsHzipdxTKUs3I9EOAPmnIimEeJOemqRlRDOp9LIj+96wtxZejF51gNibmoGq8KoqbT1ssAI5po/E3J+vEtXGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.121.0.tgz",
+      "integrity": "sha512-v1APOTkCp+RWOIDAHRoaeW/UoaHF15a60E8eUL6kUQXh+i4K7PBwq2Wi7jm8p0ymID5/m/oC1w3W31Z/+r7HQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.121.0.tgz",
+      "integrity": "sha512-PmqPQuqHZyFVWA4ycr0eu4VnTMmq9laOHZd+8R359w6kzuNZPvmmunmNJ8ybkm769A0nCoVp3TJ6dUz7B3FYIQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.121.0.tgz",
+      "integrity": "sha512-vF24htj+MOH+Q7y9A8NuC6pUZu8t/C2Fr/kDOi2OcNf28oogr2xadBPXAbml802E8wRAVfbta6YLDQTearz+jw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.121.0.tgz",
+      "integrity": "sha512-wjH8cIG2Lu/3d64iZpbYr73hREMgKAfu7fqpXjgM2S16y2zhTfDIp8EQjxO8vlDtKP5Rc7waZW72lh8nZtWrpA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.121.0.tgz",
+      "integrity": "sha512-qT663J/W8yQFw3dtscbEi9LKJevr20V7uWs2MPGTnvNZ3rm8anhhE16gXGpxDOHeg9raySaSHKhd4IGa3YZvuw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.121.0.tgz",
+      "integrity": "sha512-mYNe4NhVvDBbPkAP8JaVS8lC1dsoJZWH5WCjpw5E+sjhk1R08wt3NnXYUzum7tIiWPfgQxbCMcoxgeemFASbRw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.121.0.tgz",
+      "integrity": "sha512-+QiFoGxhAbaI/amqX567784cDyyuZIpinBrJNxUzb+/L2aBRX67mN6Jv40pqduHf15yYByI+K5gUEygCuv0z9w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.121.0.tgz",
+      "integrity": "sha512-9ykEgyTa5JD/Uhv2sttbKnCfl2PieUfOjyxJC/oDL2UO0qtXOtjPLl7H8Kaj5G7p3hIvFgu3YWvAxvE0sqY+hQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.121.0.tgz",
+      "integrity": "sha512-DB1EW5VHZdc1lIRjOI3bW/wV6R6y0xlfvdVrqj6kKi7Ayu2U3UqUBdq9KviVkcUGd5Oq+dROqvUEEFRXGAM7EQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.121.0.tgz",
+      "integrity": "sha512-s4lfobX9p4kPTclvMiH3gcQUd88VlnkMTF6n2MTMDAyX5FPNRhhRSFZK05Ykhf8Zy5NibV4PbGR6DnK7FGNN6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.121.0.tgz",
+      "integrity": "sha512-P9KlyTpuBuMi3NRGpJO8MicuGZfOoqZVRP1WjOecwx8yk4L/+mrCRNc5egSi0byhuReblBF2oVoDSMgV9Bj4Hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.121.0.tgz",
+      "integrity": "sha512-R+4jrWOfF2OAPPhj3Eb3U5CaKNAH9/btMveMULIrcNW/hjfysFQlF8wE0GaVBr81dWz8JLgQlsxwctoL78JwXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.121.0.tgz",
+      "integrity": "sha512-5TFISkPTymKvsmIlKasPVTPuWxzCcrT8pM+p77+mtQbIZDd1UC8zww4CJcRI46kolmgrEX6QpKO8AvWMVZ+ifw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
+      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.121.0.tgz",
+      "integrity": "sha512-V0pxh4mql4XTt3aiEtRNUeBAUFOw5jzZNxPABLaOKAWrVzSr9+XUaB095lY7jqMf5t8vkfh8NManGB28zanYKw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.121.0.tgz",
+      "integrity": "sha512-4Ob1qvYMPnlF2N9rdmKdkQFdrq16QVcQwBsO8yiPZXof0fHKFF+LmQV501XFbi7lHyrKm8rlJRfQ/M8bZZPVLw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.121.0.tgz",
+      "integrity": "sha512-BOp1KCzdboB1tPqoCPXgntgFs0jjeSyOXHzgxVFR7B/qfr3F8r4YDacHkTOUNXtDgM8YwKnkf3rE5gwALYX7NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.121.0.tgz",
+      "integrity": "sha512-CGtOARQb9tyv7ECgdAlFxi0Fv7lmzvmlm2rpD/RdijOO9rfk/JvB1CjT8EnoD+tjna/IYgKKw3IV7objRb+aYw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@oxc-resolver/binding-android-arm-eabi": {
@@ -10259,9 +10628,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.13.6",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
-      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -11308,9 +11677,9 @@
       }
     },
     "node_modules/knip": {
-      "version": "5.88.0",
-      "resolved": "https://registry.npmjs.org/knip/-/knip-5.88.0.tgz",
-      "integrity": "sha512-FZjQYLYwUbVrtC3C1cKyEMMqR4K2ZlkQLZszJgF5cfDo4GUSBZAdAV0P3eyzZrkssRoghLJQA9HTQUW7G+Tc8Q==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/knip/-/knip-6.3.1.tgz",
+      "integrity": "sha512-22kLJloVcOVOAudCxlFOC0ICAMme7dKsS7pVTEnrmyKGpswb8ieznvAiSKUeFVDJhb01ect6dkDc1Ha1g1sPpg==",
       "dev": true,
       "funding": [
         {
@@ -11327,12 +11696,14 @@
         "@nodelib/fs.walk": "^1.2.3",
         "fast-glob": "^3.3.3",
         "formatly": "^0.3.0",
+        "get-tsconfig": "4.13.7",
         "jiti": "^2.6.0",
         "minimist": "^1.2.8",
+        "oxc-parser": "^0.121.0",
         "oxc-resolver": "^11.19.1",
         "picocolors": "^1.1.1",
         "picomatch": "^4.0.1",
-        "smol-toml": "^1.5.2",
+        "smol-toml": "^1.6.1",
         "strip-json-comments": "5.0.3",
         "unbash": "^2.2.0",
         "yaml": "^2.8.2",
@@ -11343,11 +11714,7 @@
         "knip-bun": "bin/knip-bun.js"
       },
       "engines": {
-        "node": ">=18.18.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18",
-        "typescript": ">=5.0.4 <7"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/knip/node_modules/jiti": {
@@ -13286,6 +13653,44 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/oxc-parser": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.121.0.tgz",
+      "integrity": "sha512-ek9o58+SCv6AV7nchiAcUJy1DNE2CC5WRdBcO0mF+W4oRjNQfPO7b3pLjTHSFECpHkKGOZSQxx3hk8viIL5YCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.121.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.121.0",
+        "@oxc-parser/binding-android-arm64": "0.121.0",
+        "@oxc-parser/binding-darwin-arm64": "0.121.0",
+        "@oxc-parser/binding-darwin-x64": "0.121.0",
+        "@oxc-parser/binding-freebsd-x64": "0.121.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.121.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.121.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.121.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.121.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.121.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.121.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.121.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.121.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.121.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.121.0"
+      }
+    },
     "node_modules/oxc-resolver": {
       "version": "11.19.1",
       "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.19.1.tgz",
@@ -14886,9 +15291,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
-      "integrity": "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {

--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1012.0",
-        "@aws-sdk/s3-request-presigner": "^3.986.0",
+        "@aws-sdk/s3-request-presigner": "^3.1027.0",
         "@dnd-kit/core": "^6.3.1",
         "@next-auth/prisma-adapter": "^1.0.7",
         "@prisma/client": "5.22.0",
@@ -376,40 +376,23 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.9.tgz",
-      "integrity": "sha512-2aAUwudVQ3uNkCfkBLQwNVD2jkfb299NSeDueXsT2NcNdFrWtHRkiQzX3wk47UFYbm87BkdxrsAJcQO7PdQOhA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.21",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/signature-v4": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@aws-sdk/core": {
-      "version": "3.973.21",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.21.tgz",
-      "integrity": "sha512-OTUcDX9Yfz/FLKbHjiMaP9D4Hs44lYJzN7zBcrK2nDmBt0Wr8D6nYt12QoBkZsW0nVMFsTIGaZCrsU9zCcIMXQ==",
+      "version": "3.973.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.27.tgz",
+      "integrity": "sha512-CUZ5m8hwMCH6OYI4Li/WgMfIEx10Q2PLI9Y3XOUTPGZJ53aZ0007jCv+X/ywsaERyKPdw5MRZWk877roQksQ4A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/xml-builder": "^3.972.12",
-        "@smithy/core": "^3.23.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/signature-v4": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.6",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/xml-builder": "^3.972.17",
+        "@smithy/core": "^3.23.14",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/signature-v4": "^5.3.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
         "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-middleware": "^4.2.13",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -706,23 +689,23 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.21",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.21.tgz",
-      "integrity": "sha512-SXkHy8OET88y4NaSui3gMfoTpg4jHvcbAVXYJuP74vsgsJKCv/vzWM+0hVJ1W+EBOghd+qFIud80ZiuPt2RXRw==",
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.28.tgz",
+      "integrity": "sha512-qJHcJQH9UNPUrnPlRtCozKjtqAaypQ5IgQxTNoPsVYIQeuwNIA8Rwt3NvGij1vCDYDfCmZaPLpnJEHlZXeFqmg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.21",
-        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/types": "^3.973.7",
         "@aws-sdk/util-arn-parser": "^3.972.3",
-        "@smithy/core": "^3.23.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/signature-v4": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.6",
-        "@smithy/types": "^4.13.1",
+        "@smithy/core": "^3.23.14",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/signature-v4": "^5.3.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
         "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-stream": "^4.5.20",
+        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-stream": "^4.5.22",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -829,18 +812,18 @@
       }
     },
     "node_modules/@aws-sdk/s3-request-presigner": {
-      "version": "3.996.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.996.0.tgz",
-      "integrity": "sha512-YcMYpdwEYlfDdd+n6YiyVUtsy+WaVZbiSIv8q8/kKyoCKLTNOFS17S6YBxxEMeKCF0LnKYq4SOUNDK4sdVGTQA==",
+      "version": "3.1027.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1027.0.tgz",
+      "integrity": "sha512-CkP0x3O/B9z0Y7jGx8ccfva8exKcSyVoRIBhdneDRLcQWBl6VQ0TvzqCxM3qwqCnDxbcLuG3ekUd5MykFbIVxQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/signature-v4-multi-region": "3.996.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-format-url": "^3.972.3",
-        "@smithy/middleware-endpoint": "^4.4.16",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.5",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.16",
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/util-format-url": "^3.972.9",
+        "@smithy/middleware-endpoint": "^4.4.29",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -848,16 +831,16 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.0.tgz",
-      "integrity": "sha512-CLSrCdBoyIXSthaUcDzKw3fzRNbbyA/BawEMQBxsybYTZhGeC9P9p2DXuqTqVvla+PtEXBgRq0/Sgz2fEOBKyg==",
+      "version": "3.996.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.16.tgz",
+      "integrity": "sha512-EMdXYB4r/k5RWq86fugjRhid5JA+Z6MpS7n4sij4u5/C+STrkvuf9aFu41rJA9MjUzxCLzv8U2XL8cH2GSRYpQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.12",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/signature-v4": "^5.3.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.28",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/signature-v4": "^5.3.13",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -883,12 +866,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
-      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+      "version": "3.973.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.7.tgz",
+      "integrity": "sha512-reXRwoJ6CfChoqAsBszUYajAF8Z2LRE+CRcKocvFSMpIiLOtYU3aJ9trmn6VVPAzbbY5LXF+FfmUslbXk1SYFg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -924,14 +907,14 @@
       }
     },
     "node_modules/@aws-sdk/util-format-url": {
-      "version": "3.972.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.3.tgz",
-      "integrity": "sha512-n7F2ycckcKFXa01vAsT/SJdjFHfKH9s96QHcs5gn8AaaigASICeME8WdUL9uBp8XV/OVwEt8+6gzn6KFUgQa8g==",
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.9.tgz",
+      "integrity": "sha512-fNJXHrs0ZT7Wx0KGIqKv7zLxlDXt2vqjx9z6oKUQFmpE5o4xxnSryvVHfHpIifYHWKz94hFccIldJ0YSZjlCBw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/querystring-builder": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/querystring-builder": "^4.2.13",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -988,13 +971,13 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.13.tgz",
-      "integrity": "sha512-I/+BMxM4WE/6xL0tyV7tAUDOAXmyw/va1oGr/eSly43HmLUcD1G+v96vEKAA8VoLcZ03ZQo/PWzjmN9zQErqPQ==",
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.17.tgz",
+      "integrity": "sha512-Ra7hjqAZf1OXRRMueB13qex7mFJRDK/pgCvdSFemXBT8KCGnQDPoKzHY1SjN+TjJVmnpSF14W5tJ1vDamFu+Gg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "fast-xml-parser": "5.5.6",
+        "@smithy/types": "^4.14.0",
+        "fast-xml-parser": "5.5.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6026,18 +6009,18 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.12",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.12.tgz",
-      "integrity": "sha512-o9VycsYNtgC+Dy3I0yrwCqv9CWicDnke0L7EVOrZtJpjb2t0EjaEofmMrYc0T1Kn3yk32zm6cspxF9u9Bj7e5w==",
+      "version": "3.23.14",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.14.tgz",
+      "integrity": "sha512-vJ0IhpZxZAkFYOegMKSrxw7ujhhT2pass/1UEcZ4kfl5srTAqtPU5I7MdYQoreVas3204ykCiNhY1o7Xlz6Yyg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "@smithy/url-parser": "^4.2.13",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-stream": "^4.5.20",
+        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-stream": "^4.5.22",
         "@smithy/util-utf8": "^4.2.2",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
@@ -6133,14 +6116,14 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.15",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.15.tgz",
-      "integrity": "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==",
+      "version": "5.3.16",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.16.tgz",
+      "integrity": "sha512-nYDRUIvNd4mFmuXraRWt6w5UsZTNqtj4hXJA/iiOD4tuseIdLP9Lq38teH/SZTcIFCa2f+27o7hYpIsWktJKEQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/querystring-builder": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/querystring-builder": "^4.2.13",
+        "@smithy/types": "^4.14.0",
         "@smithy/util-base64": "^4.3.2",
         "tslib": "^2.6.2"
       },
@@ -6246,18 +6229,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.26",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.26.tgz",
-      "integrity": "sha512-8Qfikvd2GVKSm8S6IbjfwFlRY9VlMrj0Dp4vTwAuhqbX7NhJKE5DQc2bnfJIcY0B+2YKMDBWfvexbSZeejDgeg==",
+      "version": "4.4.29",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.29.tgz",
+      "integrity": "sha512-R9Q/58U+qBiSARGWbAbFLczECg/RmysRksX6Q8BaQEpt75I7LI6WGDZnjuC9GXSGKljEbA7N118LhGaMbfrTXw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.12",
-        "@smithy/middleware-serde": "^4.2.15",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/core": "^3.23.14",
+        "@smithy/middleware-serde": "^4.2.17",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "@smithy/url-parser": "^4.2.13",
+        "@smithy/util-middleware": "^4.2.13",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6285,14 +6268,14 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.15",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.15.tgz",
-      "integrity": "sha512-ExYhcltZSli0pgAKOpQQe1DLFBLryeZ22605y/YS+mQpdNWekum9Ujb/jMKfJKgjtz1AZldtwA/wCYuKJgjjlg==",
+      "version": "4.2.17",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.17.tgz",
+      "integrity": "sha512-0T2mcaM6v9W1xku86Dk0bEW7aEseG6KenFkPK98XNw0ZhOqOiD1MrMsdnQw9QsL3/Oa85T53iSMlm0SZdSuIEQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/core": "^3.23.14",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6300,12 +6283,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.12.tgz",
-      "integrity": "sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==",
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.13.tgz",
+      "integrity": "sha512-g72jN/sGDLyTanrCLH9fhg3oysO3f7tQa6eWWsMyn2BiYNCgjF24n4/I9wff/5XidFvjj9ilipAoQrurTUrLvw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6313,14 +6296,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.12",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.12.tgz",
-      "integrity": "sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==",
+      "version": "4.3.13",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.13.tgz",
+      "integrity": "sha512-iGxQ04DsKXLckbgnX4ipElrOTk+IHgTyu0q0WssZfYhDm9CQWHmu6cOeI5wmWRxpXbBDhIIfXMWz5tPEtcVqbw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6328,15 +6311,14 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.0.tgz",
-      "integrity": "sha512-Rnq9vQWiR1+/I6NZZMNzJHV6pZYyEHt2ZnuV3MG8z2NNenC4i/8Kzttz7CjZiHSmsN5frhXhg17z3Zqjjhmz1A==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.2.tgz",
+      "integrity": "sha512-/oD7u8M0oj2ZTFw7GkuuHWpIxtWdLlnyNkbrWcyVYhd5RJNDuczdkb0wfnQICyNFrVPlr8YHOhamjNy3zidhmA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/querystring-builder": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/querystring-builder": "^4.2.13",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6344,12 +6326,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.12.tgz",
-      "integrity": "sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==",
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.13.tgz",
+      "integrity": "sha512-bGzUCthxRmezuxkbu9wD33wWg9KX3hJpCXpQ93vVkPrHn9ZW6KNNdY5xAUWNuRCwQ+VyboFuWirG1lZhhkcyRQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6357,12 +6339,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.12.tgz",
-      "integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
+      "version": "5.3.13",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.13.tgz",
+      "integrity": "sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6370,12 +6352,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.12.tgz",
-      "integrity": "sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==",
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.13.tgz",
+      "integrity": "sha512-tG4aOYFCZdPMjbgfhnIQ322H//ojujldp1SrHPHpBSb3NqgUp3dwiUGRJzie87hS1DYwWGqDuPaowoDF+rYCbQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.0",
         "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -6384,12 +6366,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.12.tgz",
-      "integrity": "sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==",
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.13.tgz",
+      "integrity": "sha512-hqW3Q4P+CDzUyQ87GrboGMeD7XYNMOF+CuTwu936UQRB/zeYn3jys8C3w+wMkDfY7CyyyVwZQ5cNFoG0x1pYmA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6409,12 +6391,12 @@
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.7",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.7.tgz",
-      "integrity": "sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==",
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.8.tgz",
+      "integrity": "sha512-VZCZx2bZasxdqxVgEAhREvDSlkatTPnkdWy1+Kiy8w7kYPBosW0V5IeDwzDUMvWBt56zpK658rx1cOBFOYaPaw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6422,16 +6404,16 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.12.tgz",
-      "integrity": "sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==",
+      "version": "5.3.13",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.13.tgz",
+      "integrity": "sha512-YpYSyM0vMDwKbHD/JA7bVOF6kToVRpa+FM5ateEVRpsTNu564g1muBlkTubXhSKKYXInhpADF46FPyrZcTLpXg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
         "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-middleware": "^4.2.13",
         "@smithy/util-uri-escape": "^4.2.2",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
@@ -6441,17 +6423,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.12.6",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.6.tgz",
-      "integrity": "sha512-aib3f0jiMsJ6+cvDnXipBsGDL7ztknYSVqJs1FdN9P+u9tr/VzOR7iygSh6EUOdaBeMCMSh3N0VdyYsG4o91DQ==",
+      "version": "4.12.9",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.9.tgz",
+      "integrity": "sha512-ovaLEcTU5olSeHcRXcxV6viaKtpkHZumn6Ps0yn7dRf2rRSfy794vpjOtrWDO0d1auDSvAqxO+lyhERSXQ03EQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.12",
-        "@smithy/middleware-endpoint": "^4.4.26",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-stream": "^4.5.20",
+        "@smithy/core": "^3.23.14",
+        "@smithy/middleware-endpoint": "^4.4.29",
+        "@smithy/middleware-stack": "^4.2.13",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-stream": "^4.5.22",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6459,9 +6441,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.0.tgz",
+      "integrity": "sha512-OWgntFLW88kx2qvf/c/67Vno1yuXm/f9M7QFAtVkkO29IJXGBIg0ycEaBTH0kvCtwmvZxRujrgP5a86RvsXJAQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6471,13 +6453,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.12.tgz",
-      "integrity": "sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==",
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.13.tgz",
+      "integrity": "sha512-2G03yoboIRZlZze2+PT4GZEjgwQsJjUgn6iTsvxA02bVceHR6vp4Cuk7TUnPFWKF+ffNUk3kj4COwkENS2K3vw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/querystring-parser": "^4.2.13",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6607,12 +6589,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.12.tgz",
-      "integrity": "sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==",
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.13.tgz",
+      "integrity": "sha512-GTooyrlmRTqvUen4eK7/K1p6kryF7bnDfq6XsAbIsf2mo51B/utaH+XThY6dKgNCWzMAaH/+OLmqaBuLhLWRow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6634,14 +6616,14 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.20",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.20.tgz",
-      "integrity": "sha512-4yXLm5n/B5SRBR2p8cZ90Sbv4zL4NKsgxdzCzp/83cXw2KxLEumt5p+GAVyRNZgQOSrzXn9ARpO0lUe8XSlSDw==",
+      "version": "4.5.22",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.22.tgz",
+      "integrity": "sha512-3H8iq/0BfQjUs2/4fbHZ9aG9yNzcuZs24LPkcX1Q7Z+qpqaGM8+qbGmE8zo9m2nCRgamyvS98cHdcWvR6YUsew==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/node-http-handler": "^4.5.0",
-        "@smithy/types": "^4.13.1",
+        "@smithy/fetch-http-handler": "^5.3.16",
+        "@smithy/node-http-handler": "^4.5.2",
+        "@smithy/types": "^4.14.0",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-buffer-from": "^4.2.2",
         "@smithy/util-hex-encoding": "^4.2.2",
@@ -9905,9 +9887,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.6",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.6.tgz",
-      "integrity": "sha512-3+fdZyBRVg29n4rXP0joHthhcHdPUHaIC16cuyyd1iLsuaO6Vea36MPrxgAzbZna8lhvZeRL8Bc9GP56/J9xEw==",
+      "version": "5.5.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
       "funding": [
         {
           "type": "github",
@@ -9917,8 +9899,8 @@
       "license": "MIT",
       "dependencies": {
         "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.1.3",
-        "strnum": "^2.1.2"
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -13410,9 +13392,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
-      "integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.4.0.tgz",
+      "integrity": "sha512-s4DQMxIdhj3jLFWd9LxHOplj4p9yQ4ffMGowFf3cpEgrrJjEhN0V5nxw4Ye1EViAGDoL4/1AeO6qHpqYPOzE4Q==",
       "funding": [
         {
           "type": "github",
@@ -15149,9 +15131,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.1.tgz",
-      "integrity": "sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "funding": [
         {
           "type": "github",

--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -50,7 +50,7 @@
         "next-themes": "^0.2.1",
         "nodemailer": "^7.0.13",
         "papaparse": "^5.5.3",
-        "postcss": "^8.4.33",
+        "postcss": "^8.5.9",
         "qrcode": "^1.5.4",
         "react": "^19.2.4",
         "react-day-picker": "^9.13.2",
@@ -13514,9 +13514,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
       "funding": [
         {
           "type": "opencollective",

--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -89,7 +89,7 @@
         "prettier": "^3.8.1",
         "prisma": "5.22.0",
         "ts-node": "^10.9.1",
-        "typescript": "^5.2.2",
+        "typescript": "^6.0.2",
         "vitest": "^4.0.18"
       },
       "engines": {
@@ -7018,19 +7018,19 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
-      "integrity": "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.1.tgz",
+      "integrity": "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.56.1",
-        "@typescript-eslint/type-utils": "8.56.1",
-        "@typescript-eslint/utils": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1",
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/type-utils": "8.58.1",
+        "@typescript-eslint/utils": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7040,9 +7040,9 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.56.1",
+        "@typescript-eslint/parser": "^8.58.1",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
@@ -7055,15 +7055,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
-      "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.1.tgz",
+      "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.56.1",
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/typescript-estree": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1",
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -7075,17 +7075,17 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
-      "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.1.tgz",
+      "integrity": "sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.56.1",
-        "@typescript-eslint/types": "^8.56.1",
+        "@typescript-eslint/tsconfig-utils": "^8.58.1",
+        "@typescript-eslint/types": "^8.58.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -7096,17 +7096,17 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
-      "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.1.tgz",
+      "integrity": "sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1"
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7117,9 +7117,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
-      "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.1.tgz",
+      "integrity": "sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==",
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7129,20 +7129,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.1.tgz",
-      "integrity": "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.1.tgz",
+      "integrity": "sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/typescript-estree": "8.56.1",
-        "@typescript-eslint/utils": "8.56.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1",
+        "@typescript-eslint/utils": "8.58.1",
         "debug": "^4.4.3",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7153,13 +7153,13 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
-      "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.1.tgz",
+      "integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7170,20 +7170,20 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
-      "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.1.tgz",
+      "integrity": "sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.56.1",
-        "@typescript-eslint/tsconfig-utils": "8.56.1",
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1",
+        "@typescript-eslint/project-service": "8.58.1",
+        "@typescript-eslint/tsconfig-utils": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
         "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7193,37 +7193,16 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -7233,15 +7212,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
-      "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.1.tgz",
+      "integrity": "sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.56.1",
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/typescript-estree": "8.56.1"
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7252,16 +7231,16 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
-      "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.1.tgz",
+      "integrity": "sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/types": "8.58.1",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -8157,6 +8136,27 @@
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
       "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/braces": {
       "version": "3.0.3",
@@ -15488,9 +15488,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
-      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.12"
@@ -15692,9 +15692,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -15705,15 +15705,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.56.1.tgz",
-      "integrity": "sha512-U4lM6pjmBX7J5wk4szltF7I1cGBHXZopnAXCMXb3+fZ3B/0Z3hq3wS/CCUB2NZBNAExK92mCU2tEohWuwVMsDQ==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.1.tgz",
+      "integrity": "sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.56.1",
-        "@typescript-eslint/parser": "8.56.1",
-        "@typescript-eslint/typescript-estree": "8.56.1",
-        "@typescript-eslint/utils": "8.56.1"
+        "@typescript-eslint/eslint-plugin": "8.58.1",
+        "@typescript-eslint/parser": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1",
+        "@typescript-eslint/utils": "8.58.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -15724,7 +15724,7 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/unbash": {

--- a/next/package.json
+++ b/next/package.json
@@ -98,7 +98,7 @@
     "@tailwindcss/forms": "^0.5.6",
     "@tailwindcss/typography": "^0.5.10",
     "@types/jsonwebtoken": "^9.0.7",
-    "@types/node": "^20.8.9",
+    "@types/node": "^25.5.2",
     "@types/nodemailer": "^7.0.5",
     "@vitest/coverage-v8": "^4.0.18",
     "cross-env": "^10.0.0",

--- a/next/package.json
+++ b/next/package.json
@@ -109,7 +109,7 @@
     "prettier": "^3.8.1",
     "prisma": "5.22.0",
     "ts-node": "^10.9.1",
-    "typescript": "^5.2.2",
+    "typescript": "^6.0.2",
     "vitest": "^4.0.18"
   },
   "lint-staged": {

--- a/next/package.json
+++ b/next/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1012.0",
-    "@aws-sdk/s3-request-presigner": "^3.986.0",
+    "@aws-sdk/s3-request-presigner": "^3.1027.0",
     "@dnd-kit/core": "^6.3.1",
     "@next-auth/prisma-adapter": "^1.0.7",
     "@prisma/client": "5.22.0",

--- a/next/package.json
+++ b/next/package.json
@@ -104,7 +104,7 @@
     "cross-env": "^10.0.0",
     "eslint-plugin-react-hooks": "^7.0.1",
     "husky": "^9.1.7",
-    "knip": "^5.39.0",
+    "knip": "^6.3.1",
     "lint-staged": "^15.2.10",
     "prettier": "^3.8.1",
     "prisma": "5.22.0",

--- a/next/package.json
+++ b/next/package.json
@@ -70,7 +70,7 @@
     "next-themes": "^0.2.1",
     "nodemailer": "^7.0.13",
     "papaparse": "^5.5.3",
-    "postcss": "^8.4.33",
+    "postcss": "^8.5.9",
     "qrcode": "^1.5.4",
     "react": "^19.2.4",
     "react-day-picker": "^9.13.2",

--- a/next/package.json
+++ b/next/package.json
@@ -78,7 +78,7 @@
     "react-easy-crop": "^5.5.6",
     "react-is": "^19.2.4",
     "react-markdown": "^9.0.1",
-    "recharts": "^3.7.0",
+    "recharts": "^3.8.1",
     "rehype-sanitize": "^6.0.0",
     "rehype-stringify": "^10.0.0",
     "remark": "^15.0.1",

--- a/next/prisma/migrations/20260416041000_fix_primary_review_multi_position_votes/migration.sql
+++ b/next/prisma/migrations/20260416041000_fix_primary_review_multi_position_votes/migration.sql
@@ -1,0 +1,12 @@
+-- Primary review votes are per officer position, not per user.
+-- A single user may hold multiple primary positions and must be able to vote once per position.
+DROP INDEX IF EXISTS "AmendmentVote_amendmentId_userId_phase_key";
+DROP INDEX IF EXISTS "AmendmentVote_amendmentId_userId_key";
+
+CREATE UNIQUE INDEX IF NOT EXISTS "AmendmentVote_amendmentId_userId_voting_key"
+  ON "AmendmentVote"("amendmentId", "userId")
+  WHERE phase = 'VOTING';
+
+CREATE UNIQUE INDEX IF NOT EXISTS "AmendmentVote_amendmentId_officerPositionId_phase_key"
+  ON "AmendmentVote"("amendmentId", "officerPositionId", phase)
+  WHERE "officerPositionId" IS NOT NULL;

--- a/next/prisma/schema.prisma
+++ b/next/prisma/schema.prisma
@@ -886,8 +886,6 @@ model AmendmentVote {
   amendment       Amendment        @relation(fields: [amendmentId], references: [id], onDelete: Cascade)
   user            User             @relation(fields: [userId], references: [id])
   officerPosition OfficerPosition? @relation(fields: [officerPositionId], references: [id])
-
-  @@unique([amendmentId, userId, phase])
 }
 
 model AmendmentComment {


### PR DESCRIPTION
## Summary

Promotes 22 commits from `development` to `main`. Grouped by what's shipping:

### Amendments feature (new on prod)
- Complete primary-review quorum + member-voting flow (`79b31da`, `f5f14ee`)
- Multi-position primary-review vote handling (`004429f`, `749a7d0`)
- GitHub App auth for opening/merging PRs against `rit-sse/governing-docs`
- JWT `iat` fix — previous code stripped the claim via `noTimestamp: true`, causing 401s from GitHub (`f398f7a`)
- Wizard/detail-page diff whitespace fix — stored content was trimmed but the wizard's live diff wasn't, so the two diffs disagreed near file boundaries (`f398f7a`)
- **Requires Prisma migration** `20260416041000_fix_primary_review_multi_position_votes` — runs automatically on container start via `prisma migrate deploy`
- `.env.prod` on the docker-host already has `GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY` appended (done out-of-band) so the feature works end-to-end once shipped

### Docker CI deploy fix
- `DEPLOY_PATH` corrected to `/home/administrator/deploy` (was `/home/sse-deploy/deploy`, which didn't exist)
- Added SSH ProxyJump through `eggs.se.rit.edu` — docker-host sits on a private subnet (`192.168.111.2`) and isn't reachable from GitHub runners directly
- Dedicated `ci-deploy@github-actions` ed25519 keypair minted and installed on both hops; `SSE_DEPLOY_KEY`, `SERVER_HOST`, `SERVER_USER`, `PROXY_HOST`, `PROXY_USER` secrets updated accordingly (`e424290`)
- First end-to-end CI deploy verified on development after the fix

### Dependency bumps (all dependabot)
| Package | Before | After |
|---|---|---|
| typescript | 5.9.3 | **6.0.2** (major) |
| @types/node | 20.19.33 | **25.5.2** (major) |
| knip | 5.88.0 | **6.3.1** (major, dev-only) |
| recharts | 3.7.0 | 3.8.1 |
| @aws-sdk/s3-request-presigner | — | 3.1027.0 |
| postcss | 8.5.6 | 8.5.9 |

Dev site has been running on these since their PRs merged; no regressions observed, but the major bumps deserve a final eyeball.

## Test plan

- [ ] CI passes (Lint / Typecheck / Test / Knip / Docker CI build+push+deploy)
- [ ] Visit `https://sse.rit.edu` after merge — sanity check homepage/auth render
- [ ] Prisma migration applied cleanly (check container startup logs: `No pending migrations to apply.`)
- [ ] Create a throwaway amendment as a member, verify the wizard diff matches the detail-page diff
- [ ] Transition a primary-review-approved amendment to VOTING and confirm a PR is opened against `rit-sse/governing-docs` (no 401)
- [ ] Verify dependabot majors (TS 6.0, @types/node 25) didn't break any existing prod-only code paths

## Rollback

If something goes sideways on prod, revert the image by pulling the previous `prod` tag from GHCR or re-deploying the previous commit. The Prisma migration is small and forward-only — would need a hand-written down-migration if a full revert is required.