### PR TITLE
Fix mentor schedule 403 and unify profile avatar rendering

### DIFF
--- a/next/__tests__/authMiddleware.test.ts
+++ b/next/__tests__/authMiddleware.test.ts
@@ -21,6 +21,12 @@ vi.mock("next/server", () => {
     static next() {
       return { kind: "next" };
     }
+
+    static json(payload: unknown, init?: { status?: number }) {
+      // Serialize so existing `.body.toContain(...)` assertions keep working
+      // against the legacy plain-text substring checks.
+      return new MockNextResponse(JSON.stringify(payload), init);
+    }
   }
 
   return {
@@ -220,5 +226,75 @@ describe("authMiddleware", () => {
       req("/api/tech-committee-application", "POST")
     );
     expect((res as any).kind).toBe("next");
+  });
+
+  // ── Mentor schedule management routes ────────────────────────────────
+  // These routes' handlers enforce `isMentoringHead || isPrimary`. The
+  // middleware must match so that presidents / mentoring heads who have
+  // no Mentor row (e.g. SSE club president) can still manage the schedule.
+
+  it("allows scheduleBlock GET for anyone", async () => {
+    const res = await authMiddleware(req("/api/scheduleBlock", "GET"));
+    expect((res as any).kind).toBe("next");
+  });
+
+  it("denies scheduleBlock POST for a plain mentor without officer role", async () => {
+    mockGetGatewayAuthLevel.mockResolvedValue({
+      isUser: true,
+      isOfficer: false,
+      isMentor: true,
+      isMentoringHead: false,
+      isPrimary: false,
+    });
+
+    const res = await authMiddleware(req("/api/scheduleBlock", "POST"));
+    expect((res as any).status).toBe(403);
+    expect((res as any).body).toContain(
+      "need to be Mentoring Head or Primary Officer"
+    );
+  });
+
+  it("allows scheduleBlock POST for a primary officer with no Mentor row", async () => {
+    mockGetGatewayAuthLevel.mockResolvedValue({
+      isUser: true,
+      isOfficer: true,
+      isMentor: false,
+      isMentoringHead: false,
+      isPrimary: true,
+    });
+
+    const res = await authMiddleware(req("/api/scheduleBlock", "POST"));
+    expect((res as any).kind).toBe("next");
+  });
+
+  it("allows scheduleBlock POST for the Mentoring Head", async () => {
+    mockGetGatewayAuthLevel.mockResolvedValue({
+      isUser: true,
+      isOfficer: true,
+      isMentor: false,
+      isMentoringHead: true,
+      isPrimary: false,
+    });
+
+    const res = await authMiddleware(req("/api/scheduleBlock", "POST"));
+    expect((res as any).kind).toBe("next");
+  });
+
+  it("denies mentorSchedule PUT for anonymous users", async () => {
+    const res = await authMiddleware(req("/api/mentorSchedule", "PUT"));
+    expect((res as any).status).toBe(403);
+    expect((res as any).body).toContain(
+      "need to be Mentoring Head or Primary Officer"
+    );
+  });
+
+  it("returns access-denied as JSON so clients can safely response.json()", async () => {
+    const res = await authMiddleware(req("/api/scheduleBlock", "POST"));
+    expect((res as any).status).toBe(403);
+    const parsed = JSON.parse((res as any).body);
+    expect(parsed).toHaveProperty("error");
+    expect(parsed.error).toContain(
+      "need to be Mentoring Head or Primary Officer"
+    );
   });
 });

--- a/next/app/(main)/dashboard/MentorSection.tsx
+++ b/next/app/(main)/dashboard/MentorSection.tsx
@@ -16,6 +16,7 @@ import {
 import { toast } from "sonner";
 import { Pencil, Trash2, UserCheck, UserX, Mail, Clock } from "lucide-react";
 import MentorInviteModal from "./MentorInviteModal";
+import { getInitials } from "@/lib/userDisplay";
 
 interface Mentor {
   id: number;
@@ -42,14 +43,6 @@ interface PendingInvitation {
     email: string;
   };
 }
-
-const getInitials = (name: string) =>
-  name
-    .split(" ")
-    .filter(Boolean)
-    .map((part) => part[0]?.toUpperCase() ?? "")
-    .join("")
-    .slice(0, 2) || "?";
 
 export default function MentorSection() {
   const [mentors, setMentors] = useState<Mentor[]>([]);

--- a/next/app/(main)/dashboard/OfficerAssignmentCard.tsx
+++ b/next/app/(main)/dashboard/OfficerAssignmentCard.tsx
@@ -3,6 +3,7 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { UserPlus, X, Mail, Clock } from "lucide-react";
+import { getInitials } from "@/lib/userDisplay";
 
 interface Officer {
   id: number;
@@ -33,15 +34,6 @@ interface OfficerAssignmentCardProps {
   onCancelInvitation: () => void;
   disabled?: boolean;
   readOnly?: boolean;
-}
-
-function getInitials(name: string): string {
-  return name
-    .split(" ")
-    .map((n) => n[0])
-    .join("")
-    .toUpperCase()
-    .slice(0, 2);
 }
 
 function formatTimeAgo(dateString: string): string {

--- a/next/app/(main)/dashboard/mentoring/components/ApplicationReview.tsx
+++ b/next/app/(main)/dashboard/mentoring/components/ApplicationReview.tsx
@@ -23,6 +23,7 @@ import {
   ChevronUp,
   UserPlus,
 } from "lucide-react";
+import { getInitials } from "@/lib/userDisplay";
 
 interface MentorApplication {
   id: number;
@@ -63,14 +64,6 @@ const STATUS_COLORS: Record<string, string> = {
   rejected: "bg-red-500/20 text-red-700 dark:text-red-400",
   invited: "bg-blue-500/20 text-blue-700 dark:text-blue-400",
 };
-
-const getInitials = (name: string) =>
-  name
-    .split(" ")
-    .filter(Boolean)
-    .map((part) => part[0]?.toUpperCase() ?? "")
-    .join("")
-    .slice(0, 2) || "?";
 
 export default function ApplicationReview() {
   const [applications, setApplications] = useState<MentorApplication[]>([]);

--- a/next/app/(main)/dashboard/mentoring/components/MentorRosterManager.tsx
+++ b/next/app/(main)/dashboard/mentoring/components/MentorRosterManager.tsx
@@ -25,6 +25,7 @@ import {
   ChevronUp,
 } from "lucide-react";
 import MentorInviteModal from "../../MentorInviteModal";
+import { getInitials } from "@/lib/userDisplay";
 
 interface LatestMentorApplication {
   id: number;
@@ -129,14 +130,6 @@ export default function MentorRosterManager() {
   const [isSendingSwipe, setIsSendingSwipe] = useState(false);
   const [swipeModalOpen, setSwipeModalOpen] = useState(false);
   const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set());
-
-  const getInitials = (name: string) =>
-    name
-      .split(" ")
-      .filter(Boolean)
-      .map((part) => part[0]?.toUpperCase() ?? "")
-      .join("")
-      .slice(0, 2) || "?";
 
   const renderWrappedList = (items: string[]) => {
     if (items.length === 0)

--- a/next/app/(main)/dashboard/mentoring/components/MentorScheduleEditor.tsx
+++ b/next/app/(main)/dashboard/mentoring/components/MentorScheduleEditor.tsx
@@ -28,6 +28,8 @@ import {
 } from "@/components/ui/table";
 import { Tooltip } from "@/components/ui/tooltip";
 import { toast } from "sonner";
+import { parseApiError } from "@/lib/apiClient";
+import { getInitials } from "@/lib/userDisplay";
 import {
   X,
   User,
@@ -142,17 +144,6 @@ const TRAFFIC_LEGEND = [
 
 function getMentorColor(mentorId: number) {
   return getCategoricalColorFromSeed(mentorId);
-}
-
-function getInitials(name: string) {
-  return (
-    name
-      .split(" ")
-      .filter(Boolean)
-      .map((part) => part[0]?.toUpperCase() ?? "")
-      .join("")
-      .slice(0, 2) || "?"
-  );
 }
 
 function getTrafficPresentation(averagePeopleInLab: number) {
@@ -609,8 +600,7 @@ export default function MentorScheduleEditor({
     });
 
     if (!response.ok) {
-      const data = await response.json();
-      throw new Error(data.error || "Failed to assign mentor");
+      throw new Error(await parseApiError(response, "Failed to assign mentor"));
     }
   };
 
@@ -626,8 +616,7 @@ export default function MentorScheduleEditor({
     });
 
     if (!response.ok) {
-      const data = await response.json();
-      throw new Error(data.error || "Failed to move mentor");
+      throw new Error(await parseApiError(response, "Failed to move mentor"));
     }
   };
 
@@ -639,8 +628,7 @@ export default function MentorScheduleEditor({
     });
 
     if (!response.ok) {
-      const data = await response.json();
-      throw new Error(data.error || "Failed to remove mentor");
+      throw new Error(await parseApiError(response, "Failed to remove mentor"));
     }
   };
 
@@ -701,8 +689,7 @@ export default function MentorScheduleEditor({
         fetchBlocks();
         setClearModalOpen(false);
       } else {
-        const data = await response.json();
-        toast.error(data.error || "Failed to clear schedule");
+        toast.error(await parseApiError(response, "Failed to clear schedule"));
       }
     } catch (error) {
       console.error("Failed to clear schedule:", error);

--- a/next/app/(main)/dashboard/mentoring/components/PrintableSchedule.tsx
+++ b/next/app/(main)/dashboard/mentoring/components/PrintableSchedule.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Printer, X } from "lucide-react";
 import { getCategoricalColorFromSeed } from "@/lib/categoricalColors";
+import { getInitials } from "@/lib/userDisplay";
 
 interface ScheduleBlock {
   id: number;
@@ -34,17 +35,6 @@ const HOURS = [
   { hour: 16, label: "4pm - 5pm" },
   { hour: 17, label: "5pm - 6pm" },
 ];
-
-function getInitials(name: string): string {
-  return (
-    name
-      .split(" ")
-      .filter(Boolean)
-      .map((part) => part[0]?.toUpperCase() ?? "")
-      .join("")
-      .slice(0, 2) || "?"
-  );
-}
 
 interface PrintableScheduleProps {
   scheduleId?: number;

--- a/next/app/(main)/mentoring/schedule/page.tsx
+++ b/next/app/(main)/mentoring/schedule/page.tsx
@@ -7,6 +7,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Modal, ModalFooter } from "@/components/ui/modal";
 import { Button } from "@/components/ui/button";
 import { getCategoricalColorFromSeed } from "@/lib/categoricalColors";
+import { getInitials } from "@/lib/userDisplay";
 
 interface MentorSkill {
   id: number;
@@ -42,14 +43,6 @@ const HOURS = [
   { hour: 16, label: "4pm - 5pm" },
   { hour: 17, label: "5pm - 6pm" },
 ];
-
-const getInitials = (name: string) =>
-  name
-    .split(" ")
-    .filter(Boolean)
-    .map((part) => part[0]?.toUpperCase() ?? "")
-    .join("")
-    .slice(0, 2) || "?";
 
 export default function PublicMentorSchedulePage() {
   const [schedule, setSchedule] = useState<MentorSchedule | null>(null);

--- a/next/app/(main)/profile/[id]/ProfileContent.tsx
+++ b/next/app/(main)/profile/[id]/ProfileContent.tsx
@@ -43,6 +43,7 @@ import {
 import { toast } from "sonner";
 import ReactMarkdown from "react-markdown";
 import { isS3Key, normalizeToS3Key } from "@/lib/s3Utils";
+import { getInitials } from "@/lib/userDisplay";
 import { useProfileImage } from "@/contexts/ProfileImageContext";
 import ImageUpload from "@/components/common/ImageUpload";
 import AvailabilityGrid, {
@@ -163,16 +164,6 @@ interface ExistingApplication {
     name: string;
     isActive?: boolean;
   };
-}
-
-function getInitials(name: string): string {
-  return name
-    .split(" ")
-    .map((n) => n[0])
-    .filter(Boolean)
-    .slice(0, 2)
-    .join("")
-    .toUpperCase();
 }
 
 function parseMembershipReason(reason: string): {

--- a/next/app/(main)/settings/ProfileSettings.tsx
+++ b/next/app/(main)/settings/ProfileSettings.tsx
@@ -12,6 +12,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { toast } from "sonner";
 import ImageUpload from "@/components/common/ImageUpload";
 import { isS3Key, normalizeToS3Key } from "@/lib/s3Utils";
+import { getInitials } from "@/lib/userDisplay";
 
 const DEFAULT_IMAGE = "https://source.boringavatars.com/beam/";
 
@@ -28,16 +29,6 @@ interface UserProfile {
   graduationYear: number | null;
   major: string | null;
   coopSummary: string | null;
-}
-
-function getInitials(name: string): string {
-  return name
-    .split(" ")
-    .map((n) => n[0])
-    .filter(Boolean)
-    .slice(0, 2)
-    .join("")
-    .toUpperCase();
 }
 
 /** Strip a full LinkedIn URL down to just the username/slug */

--- a/next/components/common/ImageUpload.tsx
+++ b/next/components/common/ImageUpload.tsx
@@ -230,7 +230,7 @@ export default function ImageUpload({
               {displayUrl ? (
                 <AvatarImage src={displayUrl} alt="Upload" />
               ) : null}
-              <AvatarFallback className="text-lg font-bold">
+              <AvatarFallback className="font-sans text-lg font-bold">
                 {initials}
               </AvatarFallback>
             </Avatar>
@@ -298,7 +298,7 @@ export default function ImageUpload({
         {/* Current avatar */}
         <Avatar className={`${avatarSize} shrink-0`}>
           {displayUrl ? <AvatarImage src={displayUrl} alt="Upload" /> : null}
-          <AvatarFallback className="text-2xl font-bold">
+          <AvatarFallback className="font-sans text-2xl font-bold">
             {initials}
           </AvatarFallback>
         </Avatar>

--- a/next/components/nav/AuthButton.tsx
+++ b/next/components/nav/AuthButton.tsx
@@ -13,7 +13,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import NavAvatar from "./NavAvatar";
+import UserAvatar from "@/components/ui/user-avatar";
 import { useProfileImage } from "@/contexts/ProfileImageContext";
 
 interface AuthButtonProps {
@@ -64,10 +64,11 @@ export default function AuthButton({
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <button className="relative rounded-full outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 mr-2">
-            <NavAvatar
+            <UserAvatar
               src={userImage}
               name={userName}
               className="h-8 w-8 ring-1 ring-border/50 shadow-sm"
+              initialsClassName="text-[10px]"
             />
             {!profileComplete && (
               <span className="absolute -top-0.5 -right-0.5 h-3 w-3 rounded-full bg-destructive border-2 border-background" />

--- a/next/components/nav/NavAvatar.tsx
+++ b/next/components/nav/NavAvatar.tsx
@@ -1,69 +1,13 @@
 "use client";
 
-import * as React from "react";
-import Image from "next/image";
-import { cn } from "@/lib/utils";
-
-interface NavAvatarProps {
-  src: string | null | undefined;
-  name: string;
-  className?: string;
-}
-
-function getInitials(name: string): string {
-  return name
-    .split(" ")
-    .map((n) => n[0])
-    .filter(Boolean)
-    .slice(0, 2)
-    .join("")
-    .toUpperCase();
-}
-
 /**
- * A navbar-optimized avatar that avoids Radix Avatar's client-side loading
- * check. Both the fallback (initials) and the <img> render simultaneously —
- * the image sits on top and covers the initials the instant the browser
- * has it (often from cache, before the first paint). No JavaScript
- * onLoad gating, so there is zero empty-space flicker.
+ * Thin re-export kept for backwards compatibility. The canonical
+ * primitive now lives at `components/ui/user-avatar.tsx` and owns the
+ * shared initials + image-fallback logic used across the app (navbar,
+ * profile settings, image upload, etc.).
+ *
+ * New consumers should import `UserAvatar` directly from
+ * `@/components/ui/user-avatar`. This file can be removed once all
+ * call sites have migrated.
  */
-const NavAvatar = React.forwardRef<HTMLDivElement, NavAvatarProps>(
-  ({ src, name, className }, ref) => {
-    const initials = getInitials(name || "?");
-    const [imgFailed, setImgFailed] = React.useState(false);
-
-    // Reset failure state when src changes (e.g. after upload)
-    React.useEffect(() => {
-      setImgFailed(false);
-    }, [src]);
-
-    return (
-      <div
-        ref={ref}
-        className={cn(
-          "relative flex shrink-0 overflow-hidden rounded-full bg-muted items-center justify-center",
-          className
-        )}
-      >
-        <span className="select-none text-[10px] font-medium text-muted-foreground">
-          {initials}
-        </span>
-
-        {src && !imgFailed && (
-          <Image
-            src={src}
-            alt={name}
-            fill
-            className="absolute inset-0 h-full w-full object-cover"
-            referrerPolicy="no-referrer"
-            onError={() => setImgFailed(true)}
-            unoptimized
-          />
-        )}
-      </div>
-    );
-  }
-);
-NavAvatar.displayName = "NavAvatar";
-
-export default NavAvatar;
+export { default } from "@/components/ui/user-avatar";

--- a/next/components/ui/user-avatar.tsx
+++ b/next/components/ui/user-avatar.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import * as React from "react";
+import Image from "next/image";
+import { cn } from "@/lib/utils";
+import { getInitials } from "@/lib/userDisplay";
+
+interface UserAvatarProps {
+  /**
+   * Fully-resolved image URL for the user (upload → OAuth → null).
+   * Callers should pass `resolveUserImage(profileImageKey, googleImageURL)`
+   * from `lib/s3Utils` server-side, or `session.user.image` client-side —
+   * both produce the same string.
+   */
+  src: string | null | undefined;
+  /** Display name used to generate the initials fallback. */
+  name: string | null | undefined;
+  /**
+   * Tailwind sizing/ring classes applied to the outer round container
+   * (e.g. "h-8 w-8 ring-1 ring-border/50"). Default is `h-10 w-10`.
+   */
+  className?: string;
+  /**
+   * Override the initials font-size class. Defaults to `text-xs`, which
+   * fits comfortably at `h-8`. Use `text-base` or larger for big avatars.
+   */
+  initialsClassName?: string;
+  /** Optional alt text. Defaults to `name || "User avatar"`. */
+  alt?: string;
+}
+
+/**
+ * Canonical user-avatar primitive for the app.
+ *
+ * Renders initials as a base layer and overlays the user's picture on
+ * top. When the image is absent or fails to load (`onError`), the
+ * initials stay visible — no client-side loading flicker, no radix
+ * fallback gymnastics.
+ *
+ * Font for the initials is explicitly pinned to `font-sans font-medium`
+ * so parent fonts (serif navbar, fancy card headers, etc.) cannot leak
+ * in and cause visual inconsistency across surfaces.
+ */
+const UserAvatar = React.forwardRef<HTMLDivElement, UserAvatarProps>(
+  (
+    {
+      src,
+      name,
+      className,
+      initialsClassName = "text-xs",
+      alt,
+    },
+    ref
+  ) => {
+    const initials = getInitials(name);
+    const [imgFailed, setImgFailed] = React.useState(false);
+
+    // Reset failure state when src changes (e.g. after upload)
+    React.useEffect(() => {
+      setImgFailed(false);
+    }, [src]);
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "relative flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-full bg-muted",
+          className
+        )}
+      >
+        <span
+          className={cn(
+            "select-none font-sans font-medium text-muted-foreground",
+            initialsClassName
+          )}
+        >
+          {initials}
+        </span>
+
+        {src && !imgFailed && (
+          <Image
+            src={src}
+            alt={alt ?? name ?? "User avatar"}
+            fill
+            sizes="96px"
+            className="absolute inset-0 h-full w-full object-cover"
+            referrerPolicy="no-referrer"
+            onError={() => setImgFailed(true)}
+            unoptimized
+          />
+        )}
+      </div>
+    );
+  }
+);
+UserAvatar.displayName = "UserAvatar";
+
+export default UserAvatar;

--- a/next/lib/apiClient.ts
+++ b/next/lib/apiClient.ts
@@ -1,0 +1,46 @@
+/**
+ * Client-side helpers for dealing with `fetch` responses from our own
+ * API routes. The main job here is to extract an error message from a
+ * non-2xx response WITHOUT assuming the body is JSON — middleware and
+ * other layers can return plain text on error, and blindly calling
+ * `response.json()` throws `Unexpected token ...` in that case.
+ */
+
+/**
+ * Read the body of an errored `fetch` Response and return the best
+ * human-readable message we can find.
+ *
+ * Tries, in order:
+ *   1. JSON body with `{ error: string }` or `{ message: string }`
+ *   2. Any plain-text body
+ *   3. The passed-in fallback
+ *
+ * Safe to call on non-ok responses only; consumes the body stream.
+ */
+export async function parseApiError(
+  response: Response,
+  fallback = "Request failed"
+): Promise<string> {
+  let text = "";
+  try {
+    text = await response.text();
+  } catch {
+    return fallback;
+  }
+
+  if (!text) return fallback;
+
+  // Best-effort JSON parse. Content-Type can lie, so we just try it.
+  try {
+    const parsed = JSON.parse(text);
+    if (parsed && typeof parsed === "object") {
+      if (typeof parsed.error === "string" && parsed.error) return parsed.error;
+      if (typeof parsed.message === "string" && parsed.message)
+        return parsed.message;
+    }
+  } catch {
+    // Not JSON — fall through to the raw text.
+  }
+
+  return text.trim() || fallback;
+}

--- a/next/lib/middlewares/authentication.ts
+++ b/next/lib/middlewares/authentication.ts
@@ -75,6 +75,22 @@ const primaryOfficerVerifier = authVerifierFactory((permissions) => {
 });
 
 /**
+ * Auth verifier for mentor-schedule management (create/assign/remove
+ * blocks, rename the schedule, etc.). The underlying route handlers all
+ * enforce `canManageSchedules()` = `isMentoringHead || isPrimary`, so the
+ * middleware gate must match. Gating these routes with a mentor-only
+ * verifier used to reject primary officers (e.g. President) who have no
+ * Mentor row, with a plain-text 403 that then crashed the client's JSON
+ * parse.
+ */
+const scheduleManagementVerifier = authVerifierFactory((permissions) => {
+  return {
+    isAllowed: permissions.isMentoringHead || permissions.isPrimary,
+    authType: "Mentoring Head or Primary Officer",
+  };
+});
+
+/**
  * Auth verifier that requires any signed-in user
  */
 const signedInVerifier = authVerifierFactory((permissions) => {
@@ -155,6 +171,15 @@ const nonGetPrimaryOfficerVerifier = nonGetVerifier(primaryOfficerVerifier);
  * An auth verifier that allows GET requests but makes sure all other requests are made by mentors
  */
 const nonGetMentorVerifier = nonGetVerifier(mentorVerifier);
+
+/**
+ * An auth verifier that allows GET requests but requires Mentoring Head
+ * or Primary Officer for mutations. Matches `canManageSchedules()` in
+ * the mentor-schedule route handlers.
+ */
+const nonGetScheduleManagementVerifier = nonGetVerifier(
+  scheduleManagementVerifier
+);
 
 /**
  * Auth verifier for alumni requests - allows POST (public submissions) but requires officer for GET/PUT/DELETE
@@ -324,7 +349,7 @@ const ROUTES: { [key: string]: AuthVerifier } = {
   "mentor-availability": nonGetMentorVerifier,
   "mentor-semester": nonGetOfficerVerifier,
   "mentoring-headcount": headcountSubmissionVerifier,
-  mentorSchedule: nonGetMentorVerifier,
+  mentorSchedule: nonGetScheduleManagementVerifier,
   mentorSkill: nonGetMentorVerifier,
   officer: nonGetPrimaryOfficerVerifier,
   "officer-positions": nonGetPrimaryOfficerVerifier,
@@ -332,8 +357,8 @@ const ROUTES: { [key: string]: AuthVerifier } = {
   projectContributor: nonGetOfficerVerifier,
   purchasing: officerVerifier, // All purchasing routes require officer auth
   quotes: quoteVerifier,
-  schedule: nonGetMentorVerifier,
-  scheduleBlock: nonGetMentorVerifier,
+  schedule: nonGetScheduleManagementVerifier,
+  scheduleBlock: nonGetScheduleManagementVerifier,
   skills: nonGetOfficerVerifier,
   sponsor: nonGetOfficerVerifier,
   "swipe-access": officerVerifier,
@@ -345,11 +370,11 @@ const ROUTES: { [key: string]: AuthVerifier } = {
 
 const accessDenied = (authType: string, request: NextRequest) => {
   const { pathname } = request.nextUrl;
-  return new NextResponse(
-    `Access Denied; need to be ${authType} to access ${request.method} ${pathname}`,
+  return NextResponse.json(
     {
-      status: 403,
-    }
+      error: `Access Denied; need to be ${authType} to access ${request.method} ${pathname}`,
+    },
+    { status: 403 }
   );
 };
 

--- a/next/lib/userDisplay.ts
+++ b/next/lib/userDisplay.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared display-layer helpers for rendering users — canonical source
+ * of truth so that the navbar, profile settings, image upload, and any
+ * future surface all derive identical strings from the same name.
+ */
+
+/**
+ * Two-character uppercase initials derived from a display name.
+ * - Splits on any run of whitespace (not just a single space).
+ * - Strips empty tokens (double spaces, leading/trailing whitespace).
+ * - Takes the first character of the first two word tokens.
+ * - Returns "?" when the name is missing or empty.
+ *
+ * Examples:
+ *   getInitials("Jakob Langtry")          // "JL"
+ *   getInitials("  Jakob   Langtry  ")    // "JL"
+ *   getInitials("Ben Bowen")              // "BB"
+ *   getInitials("Cher")                   // "C"
+ *   getInitials("")                       // "?"
+ *   getInitials(null)                     // "?"
+ */
+export function getInitials(name: string | null | undefined): string {
+  const clean = (name ?? "").trim();
+  if (!clean) return "?";
+  return clean
+    .split(/\s+/)
+    .map((token) => token[0])
+    .filter(Boolean)
+    .slice(0, 2)
+    .join("")
+    .toUpperCase();
+}


### PR DESCRIPTION
Closes #490.

## Summary

- **Mentor schedule:** middleware gate on `/api/scheduleBlock`, `/api/schedule`, `/api/mentorSchedule` now matches the route handler's `canManageSchedules()` check (Mentoring Head || Primary Officer). The President — and anyone else holding a primary officer role without an active `Mentor` row — can now manage the roster again.
- **Access-denied response:** `accessDenied()` now returns JSON, so any future middleware/handler mismatch will not crash clients calling `response.json()`.
- **Error parsing:** new `lib/apiClient.ts#parseApiError` tolerates JSON/text/empty error bodies. Used in `MentorScheduleEditor`.
- **Avatars:** single canonical `getInitials` (`lib/userDisplay.ts`) and single shared `<UserAvatar>` primitive (`components/ui/user-avatar.tsx`) with pinned `font-sans` on initials. Migrated all nine call sites off their local duplicates; `NavAvatar` collapses to a re-export.

## Follow-up (not in this PR — tracked in #490)

The underlying S3 data-loss root cause for profile pictures — both the `website` and `website-dev` containers point at the `sse-web-dev` bucket, so cross-environment deletes physically wipe live objects — will be resolved by the upcoming `sse-web-prod` bucket. Once the bucket exists I will:

1. Sync extant objects from `sse-web-dev` → `sse-web-prod` from the eggs VM.
2. Flip prod `AWS_S3_BUCKET_NAME` → `sse-web-prod` + update `next.config.js` CSP.
3. Run an ad-hoc `docker exec website node -e '...'` to `HeadObject` each `User.profileImageKey` and null out orphans so affected users fall back to their Google OAuth picture until they re-upload.

Until step 1 lands, the shared avatar + matching middleware gate in this PR still help: the navbar/settings/etc. render the Google OAuth picture whenever the uploaded key 404s (the `onError` fallback), and the initials behind it now use a consistent font.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` — all 411 tests pass, including 6 new cases in `authMiddleware.test.ts` covering the mentor-schedule permission matrix and JSON body format
- [ ] Manual: sign in as president on dev → dashboard → Mentoring → Schedule editor → add/move/remove a mentor on a block
- [ ] Manual: sign in as a non-officer mentor → same flow → receive clean toast error (no JSON parse crash)
- [ ] Manual: verify avatars render in identical sans-serif font when initials are shown (navbar, settings, profile page, mentor roster, mentor schedule, application review, officer assignment card)
- [ ] Manual: verify `NavAvatar` re-export still resolves for any third-party import we might have missed

## Schema / env changes

None in this PR. Env change (`AWS_S3_BUCKET_NAME`) ships with the follow-up infra work.