### PR TITLE
Fix header banner spacing

### DIFF
--- a/next/app/(main)/layout.tsx
+++ b/next/app/(main)/layout.tsx
@@ -1,13 +1,12 @@
 // This file defines the base layout for all main scrolling pages in the application.
 
-import Navbar from "@/components/nav/Navbar";
 import Footer from "@/components/Footer";
 import ScrollToTopButton from "@/components/nav/ScrollToTopButton";
 import { Toaster } from "@/components/ui/sonner";
 import { getAuthLevel } from "@/lib/services/authLevelService";
 import { getActiveElection } from "@/lib/elections";
 import { getSiteBanners } from "@/lib/siteBanners";
-import SiteBannerList from "@/components/SiteBannerList";
+import SiteHeader from "@/components/SiteHeader";
 
 export default async function MainLayout({
   children,
@@ -22,20 +21,16 @@ export default async function MainLayout({
 
   return (
     <>
-      <Navbar
+      <SiteHeader
         serverUserId={authLevel.userId}
         serverShowDashboard={
           authLevel.isOfficer || authLevel.isMentor || authLevel.isSeAdmin
         }
         serverProfileComplete={authLevel.profileComplete}
         serverActiveElection={activeElection}
+        banners={banners}
       />
-      <SiteBannerList banners={banners} />
-      <main
-        className={`flex flex-col grow items-center px-2 pb-2 md:px-3 md:pb-3 lg:px-4 lg:pb-4 w-full overflow-x-hidden ${
-          banners.length === 0 ? "pt-20 md:pt-20 lg:pt-20" : ""
-        }`}
-      >
+      <main className="flex flex-col grow items-center px-2 pb-2 md:px-3 md:pb-3 lg:px-4 lg:pb-4 w-full overflow-x-hidden">
         {children}
       </main>
       <ScrollToTopButton />

--- a/next/components/SiteBannerList.tsx
+++ b/next/components/SiteBannerList.tsx
@@ -13,7 +13,7 @@ export default function SiteBannerList({ banners }: { banners: SiteBanner[] }) {
   if (visible.length === 0) return null;
 
   return (
-    <div className="mt-20 border-b-[2px] border-black">
+    <div className="border-b-[2px] border-black">
       {visible.map((banner, index) => {
         const content = (
           <div

--- a/next/components/SiteHeader.tsx
+++ b/next/components/SiteHeader.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useLayoutEffect, useRef, useState } from "react";
+import type { ActiveElectionSummary } from "@/lib/elections";
+import type { SiteBanner } from "@/lib/siteBanners";
+import Navbar from "@/components/nav/Navbar";
+import SiteBannerList from "@/components/SiteBannerList";
+
+type SiteHeaderProps = {
+  serverUserId?: number | null;
+  serverShowDashboard?: boolean;
+  serverProfileComplete?: boolean;
+  serverActiveElection?: ActiveElectionSummary | null;
+  banners: SiteBanner[];
+};
+
+export default function SiteHeader({
+  serverUserId,
+  serverShowDashboard,
+  serverProfileComplete,
+  serverActiveElection,
+  banners,
+}: SiteHeaderProps) {
+  const headerRef = useRef<HTMLElement | null>(null);
+  const [headerHeight, setHeaderHeight] = useState<number | null>(null);
+
+  useLayoutEffect(() => {
+    const header = headerRef.current;
+    if (!header) return;
+
+    const updateHeight = () => {
+      setHeaderHeight(Math.ceil(header.getBoundingClientRect().height));
+    };
+
+    updateHeight();
+    const observer = new ResizeObserver(updateHeight);
+    observer.observe(header);
+    window.addEventListener("resize", updateHeight);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", updateHeight);
+    };
+  }, []);
+
+  return (
+    <>
+      <header
+        ref={headerRef}
+        className="fixed left-0 top-0 z-50 w-screen bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60"
+      >
+        <Navbar
+          serverUserId={serverUserId}
+          serverShowDashboard={serverShowDashboard}
+          serverProfileComplete={serverProfileComplete}
+          serverActiveElection={serverActiveElection}
+        />
+        <SiteBannerList banners={banners} />
+      </header>
+      <div
+        aria-hidden="true"
+        className={banners.length > 0 ? "h-32 lg:h-36" : "h-20"}
+        style={headerHeight == null ? undefined : { height: headerHeight }}
+      />
+    </>
+  );
+}

--- a/next/components/nav/Navbar.tsx
+++ b/next/components/nav/Navbar.tsx
@@ -282,7 +282,7 @@ const Navbar: React.FC<NavbarProps> = ({
   return (
     <nav
       id="navbar"
-      className="fixed left-0 top-0 w-screen z-50 flex items-center justify-center bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b-[2px] border-black"
+      className="flex w-full items-center justify-center border-b-[2px] border-black"
     >
       <div
         id="nav-content"


### PR DESCRIPTION
## Summary
- wrap the fixed navbar and site banners in one measured header stack
- remove hard-coded banner top margin and main conditional top padding
- insert a spacer equal to the actual header height so page content starts below navbar plus banners

## Verification
- npm --prefix next run typecheck
- browser measurement on localhost:3000 desktop with temporary announcement: nav-to-banner gap 0px, header-to-main gap 0px
- browser measurement on localhost:3000 mobile without announcement: header-to-main gap 0px

No co-authored-by trailer.