### PR TITLE
Add gutter below site header

### DIFF
--- a/next/components/SiteHeader.tsx
+++ b/next/components/SiteHeader.tsx
@@ -6,6 +6,8 @@ import type { SiteBanner } from "@/lib/siteBanners";
 import Navbar from "@/components/nav/Navbar";
 import SiteBannerList from "@/components/SiteBannerList";
 
+const HEADER_CONTENT_GUTTER_PX = 12;
+
 type SiteHeaderProps = {
   serverUserId?: number | null;
   serverShowDashboard?: boolean;
@@ -59,8 +61,12 @@ export default function SiteHeader({
       </header>
       <div
         aria-hidden="true"
-        className={banners.length > 0 ? "h-32 lg:h-36" : "h-20"}
-        style={headerHeight == null ? undefined : { height: headerHeight }}
+        className={banners.length > 0 ? "h-36 lg:h-40" : "h-24"}
+        style={
+          headerHeight == null
+            ? undefined
+            : { height: headerHeight + HEADER_CONTENT_GUTTER_PX }
+        }
       />
     </>
   );


### PR DESCRIPTION
## Summary
- add a 12px gutter after the fixed site header spacer
- preserve the direct navbar-to-banner attachment while keeping page content from touching the header border
- adjust fallback spacer heights for first paint before header measurement runs

## Verification
- npm --prefix next run typecheck
- browser measurement without banner: header-to-content gap 12px
- browser measurement with temporary announcement banner: nav-to-banner gap 0px, header-to-content gap 12px

No co-authored-by trailer.