### PR TITLE
Give Vice President a reveal slide

### DIFF
--- a/next/app/(main)/elections/[slug]/reveal/page.tsx
+++ b/next/app/(main)/elections/[slug]/reveal/page.tsx
@@ -1,6 +1,5 @@
 import { redirect } from "next/navigation";
 import {
-  PRESIDENT_TITLE,
   VICE_PRESIDENT_TITLE,
   compareByPrimaryOrder,
   tallyElectionForDisplay,
@@ -54,33 +53,13 @@ export default async function ElectionResultsRevealPage({
     if (!r.winner) continue;
 
     if (r.ticketDerived && r.officeTitle === VICE_PRESIDENT_TITLE) {
-      // VP slide — no nomination record; pull the invitee from the
-      // presidential office's running-mate invitation.
-      const presidentOffice = election.offices.find(
-        (o) => o.officerPosition.title === PRESIDENT_TITLE
-      );
-      let inviteeUserId = 0;
-      let inviteeName = r.winner.name;
-      let inviteeImage: string | null = null;
-      if (presidentOffice) {
-        for (const nomination of presidentOffice.nominations) {
-          const inv = nomination.runningMateInvitation;
-          if (inv && inv.status === "ACCEPTED" && inv.invitee) {
-            inviteeUserId = inv.invitee.id;
-            inviteeName = inv.invitee.name;
-            inviteeImage = resolveUserImage(
-              inv.invitee.profileImageKey ?? null,
-              inv.invitee.googleImageURL ?? null
-            );
-            break;
-          }
-        }
-      }
+      // VP slide — no nomination record. The display tally already resolves
+      // the winning presidential ticket's accepted running mate.
       slides.push({
         officeTitle: VICE_PRESIDENT_TITLE,
-        winnerName: inviteeName,
-        winnerUserId: inviteeUserId,
-        winnerImage: inviteeImage,
+        winnerName: r.winner.name,
+        winnerUserId: r.winner.userId,
+        winnerImage: r.winner.image,
         statement:
           "Elected as the running mate on the winning presidential ticket.",
         yearLevel: null,

--- a/next/lib/elections.ts
+++ b/next/lib/elections.ts
@@ -1077,20 +1077,23 @@ export async function tallyElectionForDisplay(slug: string) {
   const presidentOffice = election.offices.find(
     (o) => o.officerPosition.title === PRESIDENT_TITLE
   );
-  const vpOffice = election.offices.find(
-    (o) => o.officerPosition.title === VICE_PRESIDENT_TITLE
-  );
   const presidentResult = rawResults.find(
     (r) => r.officeTitle === PRESIDENT_TITLE
   );
-  if (presidentResult?.winner && presidentOffice && vpOffice) {
+  if (presidentResult?.winner && presidentOffice) {
     const winningNomination = presidentOffice.nominations.find(
       (n) => n.id === presidentResult.winner!.id
     );
     const invitee = getAcceptedRunningMate(winningNomination);
     if (invitee) {
+      const vpOffice = election.offices.find(
+        (o) => o.officerPosition.title === VICE_PRESIDENT_TITLE
+      );
       rawResults.push({
-        officeId: vpOffice.id,
+        // Modern elections do not include Vice President as a ballotable
+        // office row. Use a stable synthetic id for display-only surfaces
+        // when the legacy row is absent.
+        officeId: vpOffice?.id ?? -presidentOffice.id,
         officeTitle: VICE_PRESIDENT_TITLE,
         status: "ok" as const,
         winner: {


### PR DESCRIPTION
## Summary
- synthesize a display-only Vice President result from the winning President ticket even when no VP office row exists
- have the reveal page use that resolved VP result directly for its own slide

## Tests
- npm --prefix next test -- elections.lib
- npm run typecheck