### PR TITLE
Optimize photos gallery performance

### DIFF
--- a/next/__tests__/aws.image.route.test.ts
+++ b/next/__tests__/aws.image.route.test.ts
@@ -41,6 +41,26 @@ describe("/api/aws/image route", () => {
     );
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toBe("image/jpeg");
+    expect(res.headers.get("cache-control")).toBe(
+      "public, max-age=300, stale-while-revalidate=600"
+    );
+  });
+
+  it("serves immutable cache headers for photo gallery keys", async () => {
+    mockSend.mockResolvedValue({
+      Body: { transformToByteArray: () => new Uint8Array([1, 2, 3]) },
+      ContentType: "image/webp",
+    });
+
+    const res = await GET(
+      req(
+        "http://localhost/api/aws/image?key=uploads/photos/gallery/2026/batch/a.webp"
+      )
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe(
+      "public, max-age=31536000, immutable"
+    );
   });
 
   it("allows library asset keys", async () => {

--- a/next/__tests__/photos.route.test.ts
+++ b/next/__tests__/photos.route.test.ts
@@ -56,6 +56,63 @@ describe("/api/photos route", () => {
     );
   });
 
+  it("returns a cursor that includes sort date and id", async () => {
+    mockPhotoFindMany.mockResolvedValue([
+      photo(3, new Date("2026-03-01T00:00:00Z")),
+      photo(2, new Date("2026-02-01T00:00:00Z")),
+      photo(1, new Date("2026-01-01T00:00:00Z")),
+    ]);
+
+    const res = await GET(req("http://localhost/api/photos?limit=2"));
+    const body = await res.json();
+    const cursor = JSON.parse(
+      Buffer.from(body.nextCursor, "base64url").toString("utf8")
+    );
+
+    expect(body.photos.map((p: any) => p.id)).toEqual([3, 2]);
+    expect(cursor).toEqual({
+      id: 2,
+      sortDate: "2026-02-01T00:00:00.000Z",
+    });
+  });
+
+  it("uses sort date and id for cursor pagination", async () => {
+    const cursor = Buffer.from(
+      JSON.stringify({
+        id: 10,
+        sortDate: "2026-02-01T00:00:00.000Z",
+      })
+    ).toString("base64url");
+
+    await GET(req(`http://localhost/api/photos?cursor=${cursor}`));
+
+    expect(mockPhotoFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          AND: [
+            { status: "published" },
+            {
+              OR: [
+                { sortDate: { lt: new Date("2026-02-01T00:00:00.000Z") } },
+                {
+                  sortDate: new Date("2026-02-01T00:00:00.000Z"),
+                  id: { lt: 10 },
+                },
+              ],
+            },
+          ],
+        },
+      })
+    );
+  });
+
+  it("rejects invalid cursors", async () => {
+    const res = await GET(req("http://localhost/api/photos?cursor=not-valid"));
+
+    expect(res.status).toBe(400);
+    expect(mockPhotoFindMany).not.toHaveBeenCalled();
+  });
+
   it("requires officer auth for admin listing", async () => {
     mockResolveAuthLevelFromRequest.mockResolvedValue({
       isOfficer: false,

--- a/next/app/(main)/photos/PhotoGrid.tsx
+++ b/next/app/(main)/photos/PhotoGrid.tsx
@@ -1,8 +1,32 @@
 "use client";
 
+import { useEffect, useMemo, useRef, useState } from "react";
 import Image from "next/image";
+import { motion, useReducedMotion } from "motion/react";
+import { useWindowVirtualizer } from "@tanstack/react-virtual";
+import { Skeleton } from "@/components/ui/skeleton";
 import type { PhotoDto } from "./PhotosClient";
 import type { PhotoMonthGroup } from "./PhotosClient";
+
+export const PHOTO_GRID_CLASSES =
+  "grid grid-cols-2 gap-1.5 sm:grid-cols-3 sm:gap-2 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-7 2xl:grid-cols-8 min-[1800px]:grid-cols-9";
+
+const HEADER_HEIGHT = 48;
+const OVERSCAN_ROWS = 12;
+
+type VirtualPhotoItem =
+  | {
+      type: "header";
+      key: string;
+      group: PhotoMonthGroup;
+    }
+  | {
+      type: "row";
+      key: string;
+      groupKey: string;
+      photos: PhotoDto[];
+      rowIndex: number;
+    };
 
 export function PhotoGrid({
   groups,
@@ -11,89 +35,182 @@ export function PhotoGrid({
   groups: PhotoMonthGroup[];
   onPhotoClick: (photo: PhotoDto) => void;
 }) {
-  return (
-    <div className="space-y-10">
-      {groups.map((group) => (
-        <section key={group.key} className="space-y-3">
-          <SectionHeader group={group} />
-          <div className="grid grid-cols-2 gap-1.5 sm:grid-cols-3 sm:gap-2 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-7">
-            {group.photos.map((photo) => (
-              <PhotoTile
-                key={photo.id}
-                photo={photo}
-                onClick={() => onPhotoClick(photo)}
-              />
-            ))}
-          </div>
-        </section>
-      ))}
-    </div>
-  );
-}
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+  const reducedMotion = useReducedMotion();
 
-function SectionHeader({ group }: { group: PhotoMonthGroup }) {
-  // Sticky inside the page so the user always knows where they are while
-  // scrolling. We pin to the top of the viewport with a soft glass layer
-  // so it reads against any photo behind it.
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node) return;
+    const measuredNode = node;
+
+    function updateMeasurements() {
+      setContainerWidth(measuredNode.getBoundingClientRect().width);
+    }
+
+    updateMeasurements();
+    const observer = new ResizeObserver(updateMeasurements);
+    observer.observe(measuredNode);
+    window.addEventListener("resize", updateMeasurements);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", updateMeasurements);
+    };
+  }, []);
+
+  const columns = useMemo(
+    () => getColumnCount(containerWidth),
+    [containerWidth]
+  );
+  const rowHeight = useMemo(
+    () => getEstimatedRowHeight(containerWidth, columns),
+    [columns, containerWidth]
+  );
+  const items = useMemo(
+    () => buildVirtualItems(groups, columns),
+    [columns, groups]
+  );
+
+  const virtualizer = useWindowVirtualizer({
+    count: items.length,
+    estimateSize: (index) =>
+      items[index]?.type === "header" ? HEADER_HEIGHT : rowHeight,
+    overscan: OVERSCAN_ROWS,
+  });
+
+  useEffect(() => {
+    virtualizer.measure();
+  }, [rowHeight, virtualizer]);
+
+  const virtualItems = virtualizer.getVirtualItems();
+
   return (
-    <div className="sticky top-0 z-10 -mx-1 flex items-baseline justify-between gap-3 px-1 py-2 backdrop-blur-md bg-surface-1/85 supports-[backdrop-filter]:bg-surface-1/70 rounded-md">
-      <div className="flex items-baseline gap-3 min-w-0">
-        <h2 className="font-display text-lg md:text-xl font-bold leading-none truncate">
-          {group.label}
-        </h2>
-        <span className="text-xs text-muted-foreground shrink-0">
-          {group.photos.length}{" "}
-          {group.photos.length === 1 ? "photo" : "photos"}
-        </span>
+    <div ref={containerRef} className="relative w-full">
+      <div
+        className="relative w-full"
+        style={{ height: `${virtualizer.getTotalSize()}px` }}
+      >
+        {virtualItems.map((virtualItem) => {
+          const item = items[virtualItem.index];
+          if (!item) return null;
+
+          return (
+            <div
+              key={item.key}
+              data-index={virtualItem.index}
+              ref={virtualizer.measureElement}
+              className="absolute left-0 top-0 w-full"
+              style={{
+                transform: `translateY(${virtualItem.start}px)`,
+              }}
+            >
+              {item.type === "header" ? (
+                <SectionHeader
+                  group={item.group}
+                  reducedMotion={Boolean(reducedMotion)}
+                />
+              ) : (
+                <div className={PHOTO_GRID_CLASSES}>
+                  {item.photos.map((photo, index) => (
+                    <PhotoTile
+                      key={photo.id}
+                      photo={photo}
+                      index={index}
+                      reducedMotion={Boolean(reducedMotion)}
+                      onClick={() => onPhotoClick(photo)}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        })}
       </div>
     </div>
   );
 }
 
-function PhotoTile({
+function SectionHeader({
+  group,
+  reducedMotion,
+}: {
+  group: PhotoMonthGroup;
+  reducedMotion: boolean;
+}) {
+  return (
+    <motion.div
+      initial={reducedMotion ? false : { opacity: 0, y: 6 }}
+      whileInView={reducedMotion ? undefined : { opacity: 1, y: 0 }}
+      viewport={{ once: true, margin: "120px" }}
+      transition={{ duration: 0.2, ease: [0.22, 1, 0.36, 1] }}
+      className="mb-3 flex h-9 items-baseline justify-between gap-3 rounded-md bg-surface-1/85 px-1 py-2 backdrop-blur-md supports-[backdrop-filter]:bg-surface-1/70"
+    >
+      <div className="flex min-w-0 items-baseline gap-3">
+        <h2 className="truncate font-display text-lg font-bold leading-none md:text-xl">
+          {group.label}
+        </h2>
+        <span className="shrink-0 text-xs text-muted-foreground">
+          {group.photos.length}{" "}
+          {group.photos.length === 1 ? "photo" : "photos"}
+        </span>
+      </div>
+    </motion.div>
+  );
+}
+
+export function PhotoTile({
   photo,
+  index,
+  reducedMotion,
   onClick,
 }: {
   photo: PhotoDto;
+  index: number;
+  reducedMotion: boolean;
   onClick: () => void;
 }) {
+  const [loaded, setLoaded] = useState(false);
   const dayLabel = formatDay(photo.sortDate);
+
   return (
-    // Outer button is a plain block-level wrapper that just owns the
-    // click target + focus ring. The square aspect comes from the
-    // percentage-padding hack on the inner div: `padding-bottom: 100%`
-    // resolves against the *width* of the parent — which CSS Grid
-    // tracks always provide — so it works even where bare
-    // `aspect-square` collapses to 0 height (a known gotcha when
-    // next/image with `fill` has no other height anchor on the
-    // parent).
-    <button
+    <motion.button
       type="button"
       onClick={onClick}
-      className="group block w-full text-left rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      initial={reducedMotion ? false : { opacity: 0, scale: 0.94, y: 10 }}
+      whileInView={reducedMotion ? undefined : { opacity: 1, scale: 1, y: 0 }}
+      whileHover={reducedMotion ? undefined : { y: -2 }}
+      viewport={{ once: true, margin: "160px" }}
+      transition={{
+        duration: 0.24,
+        delay: Math.min(index, 8) * 0.018,
+        ease: [0.22, 1, 0.36, 1],
+      }}
+      className="group block w-full rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
     >
       <div
         className={[
           "relative w-full overflow-hidden rounded-md bg-surface-2",
           "neo:border-2 neo:border-border/40 group-hover:neo:border-border",
           "clean:border clean:border-border/20 group-hover:clean:border-border/50",
-          "transition-colors duration-150",
+          "transition-[border-color,box-shadow] duration-150",
+          "group-hover:shadow-md",
         ].join(" ")}
         style={{ paddingBottom: "100%" }}
       >
+        {!loaded && <Skeleton className="absolute inset-0 rounded-none" />}
         <Image
           src={photo.imageUrl}
           alt={photo.altText || photo.caption || photo.originalFilename}
           fill
-          sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, (max-width: 1024px) 25vw, (max-width: 1280px) 20vw, 14vw"
-          className="object-cover transition-transform duration-300 ease-out group-hover:scale-[1.04]"
+          sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, (max-width: 1024px) 25vw, (max-width: 1280px) 20vw, (max-width: 1536px) 14vw, 12vw"
+          className={[
+            "object-cover transition-[opacity,transform] duration-300 ease-out group-hover:scale-[1.04]",
+            loaded ? "opacity-100" : "opacity-0",
+          ].join(" ")}
           loading="lazy"
+          onLoad={() => setLoaded(true)}
         />
 
-        {/* Subtle gradient bottom overlay shows on hover and surfaces
-            useful context: caption (or event/category fallback) + the
-            day-of-month so users can pinpoint a photo within a month
-            section at a glance. */}
         <div className="pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/85 via-black/40 to-transparent p-2 pt-6 opacity-0 transition-opacity duration-200 group-hover:opacity-100 group-focus-visible:opacity-100">
           <p className="truncate text-xs font-semibold text-white">
             {photo.caption ||
@@ -105,14 +222,54 @@ function PhotoTile({
           </p>
         </div>
 
-        {/* Tiny day chip in the corner so users can scan dates without
-            hovering — keeps the gallery legible when scrubbing. */}
         <div className="absolute left-1.5 top-1.5 rounded-sm bg-black/55 px-1.5 py-0.5 text-[10px] font-semibold text-white/95 opacity-0 transition-opacity duration-150 group-hover:opacity-100">
           {dayLabel}
         </div>
       </div>
-    </button>
+    </motion.button>
   );
+}
+
+function buildVirtualItems(
+  groups: PhotoMonthGroup[],
+  columns: number
+): VirtualPhotoItem[] {
+  const items: VirtualPhotoItem[] = [];
+  for (const group of groups) {
+    items.push({
+      type: "header",
+      key: `${group.key}-header`,
+      group,
+    });
+
+    for (let index = 0; index < group.photos.length; index += columns) {
+      items.push({
+        type: "row",
+        key: `${group.key}-row-${index / columns}`,
+        groupKey: group.key,
+        photos: group.photos.slice(index, index + columns),
+        rowIndex: index / columns,
+      });
+    }
+  }
+  return items;
+}
+
+function getColumnCount(width: number) {
+  if (width >= 1800) return 9;
+  if (width >= 1536) return 8;
+  if (width >= 1280) return 7;
+  if (width >= 1024) return 5;
+  if (width >= 768) return 4;
+  if (width >= 640) return 3;
+  return 2;
+}
+
+function getEstimatedRowHeight(width: number, columns: number) {
+  if (!width) return 180;
+  const gap = width >= 640 ? 8 : 6;
+  const tileWidth = (width - gap * (columns - 1)) / columns;
+  return tileWidth + gap;
 }
 
 function formatDay(value: string) {

--- a/next/app/(main)/photos/PhotosClient.tsx
+++ b/next/app/(main)/photos/PhotosClient.tsx
@@ -5,7 +5,7 @@ import { ImageOff, Loader2 } from "lucide-react";
 import { NeoCard, NeoCardContent } from "@/components/ui/neo-card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { PhotoFilters } from "./PhotoFilters";
-import { PhotoGrid } from "./PhotoGrid";
+import { PhotoGrid, PHOTO_GRID_CLASSES } from "./PhotoGrid";
 import { PhotoLightbox } from "./PhotoLightbox";
 
 export type PhotoEventOption = {
@@ -41,6 +41,7 @@ const EMPTY_FILTERS: Filters = {
   category: "",
   q: "",
 };
+const CLIENT_PAGE_SIZE = 90;
 
 export function PhotosClient({
   initialPhotos,
@@ -91,6 +92,7 @@ export function PhotosClient({
   const fetchPhotos = useCallback(
     async (source: Filters, cursor: string | null, append: boolean) => {
       const params = buildQuery(source);
+      params.set("limit", String(CLIENT_PAGE_SIZE));
       if (cursor) params.set("cursor", cursor);
       const response = await fetch(`/api/photos?${params.toString()}`);
       if (!response.ok) throw new Error("Failed to load photos");
@@ -251,10 +253,13 @@ export function PhotosClient({
           />
 
           {paginating && (
-            <div className="mt-8 flex items-center justify-center gap-2 text-sm text-muted-foreground">
-              <Loader2 className="h-4 w-4 animate-spin" />
-              Loading more photos…
-            </div>
+            <>
+              <PaginationSkeleton />
+              <div className="mt-4 flex items-center justify-center gap-2 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Loading more photos…
+              </div>
+            </>
           )}
 
           {!nextCursor && photos.length > 0 && (
@@ -309,23 +314,59 @@ function YearChip({
 
 function PhotoGridSkeleton() {
   return (
-    <div className="mt-6 space-y-8">
-      {[0, 1].map((section) => (
+    <div className="mt-6 space-y-10">
+      {[0, 1, 2].map((section) => (
         <div key={section} className="space-y-3">
-          <Skeleton className="h-6 w-48" />
-          <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
-            {Array.from({ length: 12 }).map((_, i) => (
+          <div className="flex items-baseline gap-3">
+            <Skeleton
+              className={[
+                "h-6",
+                section === 0 ? "w-44" : section === 1 ? "w-36" : "w-52",
+              ].join(" ")}
+            />
+            <Skeleton className="h-3 w-16" />
+          </div>
+          <div className={PHOTO_GRID_CLASSES}>
+            {Array.from({ length: section === 0 ? 24 : 16 }).map((_, i) => (
               <div
                 key={i}
                 className="relative w-full"
                 style={{ paddingBottom: "100%" }}
               >
-                <Skeleton className="absolute inset-0" />
+                <Skeleton
+                  className="absolute inset-0"
+                  style={{ opacity: 0.75 + ((i + section) % 4) * 0.06 }}
+                />
               </div>
             ))}
           </div>
         </div>
       ))}
+    </div>
+  );
+}
+
+function PaginationSkeleton() {
+  return (
+    <div className="mt-8 space-y-3" aria-hidden>
+      <div className="flex items-baseline gap-3">
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-3 w-14" />
+      </div>
+      <div className={PHOTO_GRID_CLASSES}>
+        {Array.from({ length: 12 }).map((_, i) => (
+          <div
+            key={i}
+            className="relative w-full"
+            style={{ paddingBottom: "100%" }}
+          >
+            <Skeleton
+              className="absolute inset-0"
+              style={{ opacity: 0.72 + (i % 4) * 0.06 }}
+            />
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/next/app/(main)/photos/page.tsx
+++ b/next/app/(main)/photos/page.tsx
@@ -24,12 +24,12 @@ export default async function PhotosPage() {
       orderBy: { date: "desc" },
       select: { id: true, title: true, date: true },
     }),
-    prisma.photo.findMany({
-      where: { status: "published" },
-      distinct: ["sortDate"],
-      select: { sortDate: true },
-      orderBy: { sortDate: "desc" },
-    }),
+    prisma.$queryRaw<{ year: number }[]>`
+      SELECT DISTINCT EXTRACT(YEAR FROM "sortDate")::int AS year
+      FROM "Photo"
+      WHERE "status" = 'published'
+      ORDER BY year DESC
+    `,
     prisma.photo.count({ where: { status: "published" } }),
   ]);
 
@@ -37,24 +37,31 @@ export default async function PhotosPage() {
 
   return (
     <section className="mt-16 pb-16 w-full">
-      <div className="w-full max-w-screen-xl mx-auto px-4 md:px-8">
+      <div className="w-full max-w-screen-2xl mx-auto px-3 sm:px-4 md:px-6 xl:px-8">
         <PhotosClient
           initialPhotos={initialPhotos.map(toPhotoDto)}
           initialNextCursor={
             photos.length > PAGE_SIZE
-              ? String(initialPhotos[initialPhotos.length - 1]?.id)
+              ? encodePhotoCursor(initialPhotos[initialPhotos.length - 1])
               : null
           }
           events={events.map(toEventOption)}
-          years={Array.from(
-            new Set(years.map((row) => row.sortDate.getUTCFullYear()))
-          )}
+          years={years.map((row) => Number(row.year))}
           categories={[...PHOTO_CATEGORIES]}
           totalPhotoCount={totalPhotoCount}
         />
       </div>
     </section>
   );
+}
+
+function encodePhotoCursor(photo: { sortDate: Date; id: number }) {
+  return Buffer.from(
+    JSON.stringify({
+      sortDate: photo.sortDate.toISOString(),
+      id: photo.id,
+    })
+  ).toString("base64url");
 }
 
 function toEventOption(event: {

--- a/next/app/api/aws/image/route.ts
+++ b/next/app/api/aws/image/route.ts
@@ -1,10 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { GetObjectCommand } from "@aws-sdk/client-s3";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
 import { getS3Client, getBucketName } from "@/lib/S3Client";
 
 export const dynamic = "force-dynamic";
 
 const ALLOWED_KEY_PREFIXES = ["uploads/", "assets/library/"] as const;
+const IMMUTABLE_PHOTO_GALLERY_PREFIX = "uploads/photos/gallery/";
 
 /**
  * Image proxy for S3 uploads (profile pictures, library book covers, etc.).
@@ -71,14 +74,51 @@ export async function GET(req: NextRequest) {
       status: 200,
       headers: {
         "Content-Type": response.ContentType || "application/octet-stream",
-        "Cache-Control": "public, max-age=300, stale-while-revalidate=600",
+        "Cache-Control": key.startsWith(IMMUTABLE_PHOTO_GALLERY_PREFIX)
+          ? "public, max-age=31536000, immutable"
+          : "public, max-age=300, stale-while-revalidate=600",
       },
     });
   } catch (err: any) {
     if (err.name === "NoSuchKey") {
       return NextResponse.json({ error: "Image not found" }, { status: 404 });
     }
+    const localResponse = await tryReadLocalDevelopmentImage(key);
+    if (localResponse) return localResponse;
+
     console.error("S3 image fetch error:", err);
     return NextResponse.json({ error: "Image fetch failed" }, { status: 500 });
   }
+}
+
+async function tryReadLocalDevelopmentImage(key: string) {
+  if (process.env.NODE_ENV === "production") return null;
+
+  try {
+    const publicRoot = path.join(process.cwd(), "public");
+    const resolved = path.resolve(publicRoot, key);
+    if (!resolved.startsWith(publicRoot + path.sep)) return null;
+
+    const data = await readFile(resolved);
+    return new NextResponse(data, {
+      status: 200,
+      headers: {
+        "Content-Type": contentTypeForKey(key),
+        "Cache-Control": key.startsWith(IMMUTABLE_PHOTO_GALLERY_PREFIX)
+          ? "public, max-age=31536000, immutable"
+          : "public, max-age=300, stale-while-revalidate=600",
+      },
+    });
+  } catch {
+    return null;
+  }
+}
+
+function contentTypeForKey(key: string) {
+  const extension = path.extname(key).toLowerCase();
+  if (extension === ".jpg" || extension === ".jpeg") return "image/jpeg";
+  if (extension === ".png") return "image/png";
+  if (extension === ".webp") return "image/webp";
+  if (extension === ".gif") return "image/gif";
+  return "application/octet-stream";
 }

--- a/next/app/api/photos/route.ts
+++ b/next/app/api/photos/route.ts
@@ -8,6 +8,11 @@ export const dynamic = "force-dynamic";
 const DEFAULT_LIMIT = 60;
 const MAX_LIMIT = 100;
 
+type PhotoCursor = {
+  sortDate: string;
+  id: number;
+};
+
 export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
   const requestedLimit = Number.parseInt(
@@ -18,7 +23,10 @@ export async function GET(request: NextRequest) {
     ? Math.min(Math.max(requestedLimit, 1), MAX_LIMIT)
     : DEFAULT_LIMIT;
   const cursor = searchParams.get("cursor");
-  const cursorId = cursor ? Number.parseInt(cursor, 10) : null;
+  const decodedCursor = cursor ? decodePhotoCursor(cursor) : null;
+  if (cursor && !decodedCursor) {
+    return NextResponse.json({ error: "Invalid cursor" }, { status: 400 });
+  }
   const includeHidden = searchParams.get("admin") === "true";
 
   if (includeHidden) {
@@ -50,12 +58,26 @@ export async function GET(request: NextRequest) {
     ];
   }
 
+  const effectiveWhere = decodedCursor
+    ? {
+        AND: [
+          where,
+          {
+            OR: [
+              { sortDate: { lt: new Date(decodedCursor.sortDate) } },
+              {
+                sortDate: new Date(decodedCursor.sortDate),
+                id: { lt: decodedCursor.id },
+              },
+            ],
+          },
+        ],
+      }
+    : where;
+
   const photos = await prisma.photo.findMany({
-    where,
+    where: effectiveWhere,
     take: limit + 1,
-    ...(cursorId && Number.isInteger(cursorId)
-      ? { cursor: { id: cursorId }, skip: 1 }
-      : {}),
     orderBy: [{ sortDate: "desc" }, { id: "desc" }],
     include: {
       event: {
@@ -63,12 +85,6 @@ export async function GET(request: NextRequest) {
           id: true,
           title: true,
           date: true,
-        },
-      },
-      uploadedBy: {
-        select: {
-          id: true,
-          name: true,
         },
       },
     },
@@ -91,7 +107,6 @@ export async function GET(request: NextRequest) {
             date: photo.event.date.toISOString(),
           }
         : null,
-      uploadedBy: photo.uploadedBy,
       photoDate:
         photo.exifTakenAt?.toISOString() ??
         photo.manualTakenAt?.toISOString() ??
@@ -101,6 +116,31 @@ export async function GET(request: NextRequest) {
       status: photo.status,
       originalFilename: photo.originalFilename,
     })),
-    nextCursor: hasMore ? String(page[page.length - 1]?.id) : null,
+    nextCursor: hasMore ? encodePhotoCursor(page[page.length - 1]) : null,
   });
+}
+
+function encodePhotoCursor(photo: { sortDate: Date; id: number }) {
+  return Buffer.from(
+    JSON.stringify({
+      sortDate: photo.sortDate.toISOString(),
+      id: photo.id,
+    } satisfies PhotoCursor)
+  ).toString("base64url");
+}
+
+function decodePhotoCursor(cursor: string): PhotoCursor | null {
+  try {
+    const parsed = JSON.parse(Buffer.from(cursor, "base64url").toString("utf8"));
+    if (!parsed || typeof parsed !== "object") return null;
+    const id = Number.parseInt(String(parsed.id), 10);
+    const sortDate =
+      typeof parsed.sortDate === "string" ? parsed.sortDate : null;
+    if (!Number.isInteger(id) || id < 1 || !sortDate) return null;
+    const date = new Date(sortDate);
+    if (Number.isNaN(date.getTime())) return null;
+    return { id, sortDate: date.toISOString() };
+  } catch {
+    return null;
+  }
 }

--- a/next/components/nav/Navbar.tsx
+++ b/next/components/nav/Navbar.tsx
@@ -62,6 +62,13 @@ interface NavItem {
   description: string;
 }
 
+type NavGroup = {
+  value: string;
+  label: string;
+  items: NavItem[];
+  align?: "start" | "end";
+};
+
 const studentsItems: NavItem[] = [
   {
     title: "Get Involved",
@@ -249,8 +256,13 @@ const Navbar: React.FC<NavbarProps> = ({
       { value: "students", label: "Students", items: studentsItems },
       { value: "alumni", label: "Alumni", items: alumniItems },
       { value: "companies", label: "Companies", items: companiesItems },
-      { value: "se-office", label: "SE Office", items: seOfficeWithElection },
-    ] as const;
+      {
+        value: "se-office",
+        label: "SE Office",
+        items: seOfficeWithElection,
+        align: "end",
+      },
+    ] satisfies NavGroup[];
   }, [serverActiveElection]);
 
   return (
@@ -277,6 +289,7 @@ const Navbar: React.FC<NavbarProps> = ({
             value={menuValue}
             onValueChange={handleValueChange}
             delayDuration={isMenuActive ? 100 : 1000000}
+            viewport={false}
           >
             <NavigationMenuList>
               {/* Top-level shortcut: About is its own page, no
@@ -314,7 +327,11 @@ const Navbar: React.FC<NavbarProps> = ({
                     >
                       {group.label}
                     </NavigationMenuTrigger>
-                    <NavigationMenuContent>
+                    <NavigationMenuContent
+                      className={cn(
+                        group.align === "end" && "lg:left-auto lg:right-0"
+                      )}
+                    >
                       <ul
                         className={cn(
                           "grid gap-3 p-4",

--- a/next/components/ui/navigation-menu.tsx
+++ b/next/components/ui/navigation-menu.tsx
@@ -21,7 +21,7 @@ function NavigationMenu({
       data-slot="navigation-menu"
       data-viewport={viewport}
       className={cn(
-        "relative z-10 flex max-w-max rounded-base font-heading border-border border-2 p-1 bg-surface-1 flex-1 items-center justify-center",
+        "relative z-10 flex max-w-max rounded-base font-heading border-border border-2 p-1 bg-surface-1 flex-1 items-center justify-center group/navigation-menu",
         className
       )}
       {...props}
@@ -94,7 +94,7 @@ function NavigationMenuContent({
       data-slot="navigation-menu-content"
       className={cn(
         "data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 top-0 left-0 w-full p-2 pr-2.5 md:absolute md:w-auto",
-        "group-data-[viewport=false]/navigation-menu:bg-main group-data-[viewport=false]/navigation-menu:text-main-foreground group-data-[viewport=false]/navigation-menu:data-[state=open]:animate-in group-data-[viewport=false]/navigation-menu:data-[state=closed]:animate-out group-data-[viewport=false]/navigation-menu:data-[state=closed]:zoom-out-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:zoom-in-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:fade-in-0 group-data-[viewport=false]/navigation-menu:data-[state=closed]:fade-out-0 group-data-[viewport=false]/navigation-menu:top-full group-data-[viewport=false]/navigation-menu:mt-1.5 group-data-[viewport=false]/navigation-menu:overflow-hidden group-data-[viewport=false]/navigation-menu:duration-200 **:data-[slot=navigation-menu-link]:focus:ring-0 **:data-[slot=navigation-menu-link]:focus:outline-none",
+        "group-data-[viewport=false]/navigation-menu:rounded-base group-data-[viewport=false]/navigation-menu:border-2 group-data-[viewport=false]/navigation-menu:border-border group-data-[viewport=false]/navigation-menu:bg-dropdown group-data-[viewport=false]/navigation-menu:text-foreground group-data-[viewport=false]/navigation-menu:shadow-lg group-data-[viewport=false]/navigation-menu:data-[state=open]:animate-in group-data-[viewport=false]/navigation-menu:data-[state=closed]:animate-out group-data-[viewport=false]/navigation-menu:data-[state=closed]:zoom-out-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:zoom-in-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:fade-in-0 group-data-[viewport=false]/navigation-menu:data-[state=closed]:fade-out-0 group-data-[viewport=false]/navigation-menu:top-full group-data-[viewport=false]/navigation-menu:mt-1.5 group-data-[viewport=false]/navigation-menu:overflow-hidden group-data-[viewport=false]/navigation-menu:duration-200 **:data-[slot=navigation-menu-link]:focus:ring-0 **:data-[slot=navigation-menu-link]:focus:outline-none",
         className
       )}
       {...props}

--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -30,6 +30,7 @@
         "@radix-ui/react-toggle": "^1.1.10",
         "@radix-ui/react-toggle-group": "^1.1.11",
         "@radix-ui/react-tooltip": "^1.2.8",
+        "@tanstack/react-virtual": "^3.13.24",
         "@types/papaparse": "^5.5.2",
         "@types/qrcode": "^1.5.6",
         "@types/react": "^19",
@@ -7111,6 +7112,33 @@
       },
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.24",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.24.tgz",
+      "integrity": "sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.14.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz",
+      "integrity": "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tsconfig/node10": {

--- a/next/package.json
+++ b/next/package.json
@@ -50,6 +50,7 @@
     "@radix-ui/react-toggle": "^1.1.10",
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@tanstack/react-virtual": "^3.13.24",
     "@types/papaparse": "^5.5.2",
     "@types/qrcode": "^1.5.6",
     "@types/react": "^19",

--- a/next/prisma/migrations/20260430000000_optimize_photo_gallery/migration.sql
+++ b/next/prisma/migrations/20260430000000_optimize_photo_gallery/migration.sql
@@ -1,0 +1,3 @@
+CREATE INDEX "Photo_status_sortDate_id_idx" ON "Photo"("status", "sortDate", "id");
+CREATE INDEX "Photo_status_category_sortDate_id_idx" ON "Photo"("status", "category", "sortDate", "id");
+CREATE INDEX "Photo_status_eventId_sortDate_id_idx" ON "Photo"("status", "eventId", "sortDate", "id");

--- a/next/prisma/schema.prisma
+++ b/next/prisma/schema.prisma
@@ -844,6 +844,9 @@ model Photo {
   batchId String @db.VarChar(80)
 
   @@index([status, sortDate])
+  @@index([status, sortDate, id])
+  @@index([status, category, sortDate, id])
+  @@index([status, eventId, sortDate, id])
   @@index([eventId])
   @@index([category])
   @@index([batchId])


### PR DESCRIPTION
## Summary
- virtualize the public photos grid and widen/densify the layout for large archives
- add animated photo tile entry states, image-load skeletons, and pagination skeletons
- switch photo pagination to stable sortDate/id keyset cursors with supporting indexes
- improve immutable cache headers for gallery images and add a dev-only local public-file fallback for image proxy testing
- fix desktop navbar dropdown alignment by using trigger-local NavigationMenu content

## Testing
- npm test -- photos.route.test.ts aws.image.route.test.ts
- npm run typecheck
- npm run lint

