### PR TITLE
Add public /nominate page with semester auto-kickoff

### DIFF
--- a/next/__tests__/electionAutoKickoff.test.ts
+++ b/next/__tests__/electionAutoKickoff.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockElectionCount,
+  mockElectionFindFirst,
+  mockElectionFindUnique,
+  mockElectionCreate,
+  mockElectionOfficeCreateMany,
+  mockOfficerFindFirst,
+  mockOfficerPositionFindMany,
+  mockTransaction,
+} = vi.hoisted(() => ({
+  mockElectionCount: vi.fn(),
+  mockElectionFindFirst: vi.fn(),
+  mockElectionFindUnique: vi.fn(),
+  mockElectionCreate: vi.fn(),
+  mockElectionOfficeCreateMany: vi.fn(),
+  mockOfficerFindFirst: vi.fn(),
+  mockOfficerPositionFindMany: vi.fn(),
+  mockTransaction: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    election: {
+      count: mockElectionCount,
+      findFirst: mockElectionFindFirst,
+      findUnique: mockElectionFindUnique,
+      create: mockElectionCreate,
+    },
+    electionOffice: {
+      createMany: mockElectionOfficeCreateMany,
+    },
+    officer: {
+      findFirst: mockOfficerFindFirst,
+    },
+    officerPosition: {
+      findMany: mockOfficerPositionFindMany,
+    },
+    $transaction: mockTransaction,
+  },
+}));
+
+import {
+  shouldKickoffNewElection,
+  kickoffElectionForCurrentTerm,
+} from "@/lib/electionAutoKickoff";
+
+describe("electionAutoKickoff", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockElectionFindUnique.mockResolvedValue(null); // slug is unique by default
+    mockTransaction.mockImplementation(async (fn) =>
+      fn({
+        election: {
+          create: mockElectionCreate,
+        },
+        electionOffice: {
+          createMany: mockElectionOfficeCreateMany,
+        },
+      })
+    );
+  });
+
+  describe("shouldKickoffNewElection", () => {
+    it("returns false when an in-flight election already exists", async () => {
+      mockElectionCount.mockResolvedValue(1);
+      const result = await shouldKickoffNewElection(
+        new Date("2026-04-30T00:00:00Z")
+      );
+      expect(result).toBe(false);
+      expect(mockElectionCount).toHaveBeenCalledWith({
+        where: expect.objectContaining({
+          status: expect.objectContaining({ in: expect.any(Array) }),
+        }),
+      });
+    });
+
+    it("returns true on bootstrap (no certified history) when nothing in flight", async () => {
+      mockElectionCount.mockResolvedValue(0);
+      mockElectionFindFirst.mockResolvedValue(null);
+      const result = await shouldKickoffNewElection(
+        new Date("2026-04-30T00:00:00Z")
+      );
+      expect(result).toBe(true);
+    });
+
+    it("returns false when last certified election is for the current term", async () => {
+      mockElectionCount.mockResolvedValue(0);
+      // certified mid-April 2026 (SPRING 2026)
+      mockElectionFindFirst.mockResolvedValue({
+        nominationsCloseAt: new Date("2026-04-15T00:00:00Z"),
+        certifiedAt: new Date("2026-04-22T00:00:00Z"),
+      });
+      const result = await shouldKickoffNewElection(
+        new Date("2026-04-30T00:00:00Z") // also SPRING 2026
+      );
+      expect(result).toBe(false);
+    });
+
+    it("returns true when last certified election is for a prior term", async () => {
+      mockElectionCount.mockResolvedValue(0);
+      // certified during FALL 2025 — and now we're in SPRING 2026
+      mockElectionFindFirst.mockResolvedValue({
+        nominationsCloseAt: new Date("2025-11-15T00:00:00Z"),
+        certifiedAt: new Date("2025-11-22T00:00:00Z"),
+      });
+      const result = await shouldKickoffNewElection(
+        new Date("2026-02-15T00:00:00Z") // SPRING 2026
+      );
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("kickoffElectionForCurrentTerm", () => {
+    it("no-ops when shouldKickoffNewElection returns false", async () => {
+      mockElectionCount.mockResolvedValue(1); // in-flight election exists
+      const result = await kickoffElectionForCurrentTerm({
+        atDate: new Date("2026-04-30T00:00:00Z"),
+      });
+      expect(result.created).toBe(false);
+      expect(mockElectionCreate).not.toHaveBeenCalled();
+      expect(mockElectionOfficeCreateMany).not.toHaveBeenCalled();
+    });
+
+    it("creates a new election + offices when conditions are met", async () => {
+      mockElectionCount.mockResolvedValue(0);
+      mockElectionFindFirst
+        // last certified — prior term
+        .mockResolvedValueOnce({
+          nominationsCloseAt: new Date("2025-11-15T00:00:00Z"),
+          certifiedAt: new Date("2025-11-22T00:00:00Z"),
+        })
+        // currently active President for actor lookup
+        .mockResolvedValueOnce(null) // no active president
+        // active SE office holder
+        .mockResolvedValueOnce(null) // none either
+        // last certifier as fallback
+        .mockResolvedValueOnce({ certifiedById: 99 });
+      // pickKickoffActor uses officer.findFirst, not election.findFirst —
+      // mock those instead
+      mockOfficerFindFirst
+        .mockResolvedValueOnce({ user_id: 17 }) // active president found
+        .mockResolvedValueOnce(null);
+
+      mockOfficerPositionFindMany.mockResolvedValue([
+        { id: 1, title: "President" },
+        { id: 2, title: "Secretary" },
+        { id: 3, title: "Treasurer" },
+        { id: 4, title: "Mentoring Head" },
+      ]);
+
+      mockElectionCreate.mockResolvedValue({ id: 42, slug: "spring-2026-primary" });
+
+      const result = await kickoffElectionForCurrentTerm({
+        atDate: new Date("2026-02-15T00:00:00Z"),
+      });
+
+      expect(result.created).toBe(true);
+      expect(result.electionId).toBe(42);
+      expect(mockElectionCreate).toHaveBeenCalledTimes(1);
+      const createArgs = mockElectionCreate.mock.calls[0][0];
+      expect(createArgs.data.title).toBe("Spring 2026 Primary Officer Election");
+      expect(createArgs.data.slug).toBe("spring-2026-primary");
+      expect(createArgs.data.status).toBe("NOMINATIONS_OPEN");
+      expect(createArgs.data.createdById).toBe(17);
+
+      // 4 office rows for the 4 primary positions returned
+      expect(mockElectionOfficeCreateMany).toHaveBeenCalledTimes(1);
+      expect(mockElectionOfficeCreateMany.mock.calls[0][0].data).toHaveLength(4);
+    });
+
+    it("returns a useful reason when no actor is available", async () => {
+      mockElectionCount.mockResolvedValue(0);
+      mockElectionFindFirst
+        .mockResolvedValueOnce({
+          nominationsCloseAt: new Date("2025-11-15T00:00:00Z"),
+          certifiedAt: new Date("2025-11-22T00:00:00Z"),
+        })
+        .mockResolvedValueOnce(null); // no last certifier
+      mockOfficerFindFirst.mockResolvedValue(null); // no active president, no SE office
+
+      const result = await kickoffElectionForCurrentTerm({
+        atDate: new Date("2026-02-15T00:00:00Z"),
+      });
+      expect(result.created).toBe(false);
+      expect(result.reason).toMatch(/no eligible kickoff actor/i);
+    });
+  });
+});

--- a/next/app/(main)/nominate/NominateClient.tsx
+++ b/next/app/(main)/nominate/NominateClient.tsx
@@ -1,0 +1,505 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import Link from "next/link";
+import { signIn, useSession } from "next-auth/react";
+import { toast } from "sonner";
+import { Calendar, CheckCircle2, GraduationCap, UserPlus, Vote } from "lucide-react";
+
+import { NeoCard, NeoCardContent } from "@/components/ui/neo-card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ElectionPhaseTimeline } from "@/components/elections/ElectionPhaseTimeline";
+import { ElectionAvatar } from "@/components/elections/ElectionAvatar";
+import UserSearchInviteModal, {
+  type UserSearchResult,
+} from "@/components/common/UserSearchInviteModal";
+
+import type {
+  NominateData,
+  NominateOpenElection,
+  NominateOffice,
+} from "./types";
+
+interface NominateClientProps {
+  data: NominateData;
+}
+
+interface ReceiptState {
+  position: string;
+}
+
+function termLabelFromTitle(title: string): string {
+  // Strip the trailing "Primary Officer Election" so the hero shows just
+  // the term label ("Spring 2026"), reading like a section name rather
+  // than a registry record.
+  return title
+    .replace(/\s+Primary Officer Election\s*$/i, "")
+    .replace(/\s+Election\s*$/i, "")
+    .trim();
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function daysUntil(iso: string): number {
+  const ms = new Date(iso).getTime() - Date.now();
+  return Math.max(0, Math.ceil(ms / (24 * 60 * 60 * 1000)));
+}
+
+export default function NominateClient({ data }: NominateClientProps) {
+  const { data: session, status: sessionStatus } = useSession();
+  const isSignedIn = !!session?.user;
+
+  const [inviteOfficeId, setInviteOfficeId] = useState<number | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [receipt, setReceipt] = useState<ReceiptState | null>(null);
+
+  const election = data.openElection;
+  const nominationsOpen = !!election;
+
+  // Submission helper passed into UserSearchInviteModal. Throws on failure
+  // so the modal can surface the inline error; resolves on success and
+  // flips the page to the receipt state.
+  const submitNomination = useCallback(
+    async (officeId: number, nomineeUserId: number) => {
+      if (!election) return;
+      setSubmitting(true);
+      try {
+        const response = await fetch(
+          `/api/elections/${election.id}/nominations`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              electionOfficeId: officeId,
+              nomineeUserId,
+            }),
+          }
+        );
+        if (!response.ok) {
+          const text = await response.text();
+          throw new Error(text || "Could not submit your nomination.");
+        }
+        const office = election.offices.find((o) => o.id === officeId);
+        setReceipt({ position: office?.title ?? "an office" });
+        toast.success("Nomination submitted.");
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [election]
+  );
+
+  const inviteOffice =
+    election?.offices.find((o) => o.id === inviteOfficeId) ?? null;
+
+  return (
+    <div className="w-full max-w-5xl mx-auto py-6 md:py-10 space-y-6 px-2 md:px-0">
+      <NeoCard depth={1} className="election-scope w-full">
+        <NeoCardContent className="space-y-8 p-6 md:p-8">
+          {nominationsOpen && election ? (
+            <Hero
+              title={`Nominate the next ${termLabelFromTitle(election.title)} officers`}
+              subtitle={
+                <>
+                  {election.offices.length} seat
+                  {election.offices.length === 1 ? "" : "s"} to fill. Pick a
+                  position, pick a nominee, and ship it. Nominees get an email
+                  asking them to accept or decline — you can nominate as many
+                  people as you like.
+                </>
+              }
+              badge={
+                <>
+                  Nominations open · closes {formatDate(election.nominationsCloseAt)}{" "}
+                  ({daysUntil(election.nominationsCloseAt)} days)
+                </>
+              }
+            />
+          ) : (
+            <Hero
+              title="The next ballot is being drawn up."
+              subtitle={
+                <>
+                  SSE elects new primary officers each semester. The next
+                  nomination window opens with{" "}
+                  <strong>{data.nextSemesterLabel}</strong>. Watch this page —
+                  no emails, no notifications.
+                </>
+              }
+              badge={`Resumes ${data.nextSemesterLabel}`}
+            />
+          )}
+
+          {nominationsOpen && election && (
+            <PhaseTimelineWrap election={election} />
+          )}
+
+          {receipt ? (
+            <ReceiptPanel
+              receipt={receipt}
+              electionSlug={election?.slug ?? ""}
+              onAgain={() => {
+                setReceipt(null);
+                setInviteOfficeId(null);
+              }}
+            />
+          ) : nominationsOpen && election ? (
+            !isSignedIn && sessionStatus !== "loading" ? (
+              <SignInPanel />
+            ) : !data.viewerCanNominate ? (
+              <NotMemberPanel />
+            ) : (
+              <OfficePicker
+                offices={election.offices}
+                onPick={(officeId) => setInviteOfficeId(officeId)}
+              />
+            )
+          ) : (
+            <WaitingPanel nextSemesterLabel={data.nextSemesterLabel} />
+          )}
+        </NeoCardContent>
+      </NeoCard>
+
+      <ExplainerTiles
+        isOpen={nominationsOpen}
+        closesAt={election ? formatDate(election.nominationsCloseAt) : null}
+        votingOpensAt={election ? formatDate(election.votingOpenAt) : null}
+      />
+
+      <RoleManifestCard roles={data.roleManifest} />
+
+      {/* Modal — shared site pattern. Opens when user picks an office. */}
+      {inviteOffice && election && (
+        <UserSearchInviteModal
+          open={inviteOfficeId !== null}
+          onOpenChange={(open) => {
+            if (!open) setInviteOfficeId(null);
+          }}
+          title={`Nominate for ${inviteOffice.title}`}
+          description={
+            inviteOffice.title === "President"
+              ? "Pick an active SSE member to nominate for President. They'll choose their own VP running mate after accepting — no need to nominate a VP separately."
+              : `Pick an active SSE member to nominate for ${inviteOffice.title}. They'll get an email to accept or decline.`
+          }
+          confirmLabel={submitting ? "Submitting…" : "Send Nomination"}
+          onInvite={async (userId) => {
+            await submitNomination(inviteOffice.id, userId);
+            setInviteOfficeId(null);
+          }}
+          renderAvatar={(user: UserSearchResult) => (
+            <ElectionAvatar
+              user={user}
+              className="h-9 w-9 border-2 border-black shrink-0"
+              fallbackClassName="text-xs"
+            />
+          )}
+          searchPlaceholder="Search SSE members by name or email…"
+        />
+      )}
+    </div>
+  );
+}
+
+/* ─────────────────── sub-views ─────────────────── */
+
+function Hero({
+  badge,
+  title,
+  subtitle,
+}: {
+  badge: React.ReactNode;
+  title: string;
+  subtitle: React.ReactNode;
+}) {
+  return (
+    <header className="space-y-3">
+      <Badge variant="default" className="uppercase tracking-wider">
+        {badge}
+      </Badge>
+      <h1 className="text-3xl md:text-4xl font-display font-bold tracking-tight">
+        {title}
+      </h1>
+      <p className="text-base text-muted-foreground max-w-2xl">{subtitle}</p>
+    </header>
+  );
+}
+
+function PhaseTimelineWrap({ election }: { election: NominateOpenElection }) {
+  return (
+    <div className="rounded-lg border border-border/50 bg-surface-2 p-4">
+      <ElectionPhaseTimeline
+        status="NOMINATIONS_OPEN"
+        nominationsOpenAt={election.nominationsOpenAt}
+        nominationsCloseAt={election.nominationsCloseAt}
+        votingOpenAt={election.votingOpenAt}
+        votingCloseAt={election.votingCloseAt}
+      />
+    </div>
+  );
+}
+
+function SignInPanel() {
+  return (
+    <div className="rounded-lg border-2 border-border bg-surface-2 p-6 md:p-8 text-center space-y-4">
+      <h2 className="text-2xl font-display font-bold">Sign in to nominate</h2>
+      <p className="text-muted-foreground max-w-xl mx-auto">
+        Nominations are member-only. One sign-in with your RIT Google account
+        puts the ballot in your hands.
+      </p>
+      <Button size="lg" onClick={() => signIn("google")}>
+        Sign in with RIT Google
+      </Button>
+    </div>
+  );
+}
+
+function NotMemberPanel() {
+  return (
+    <div className="rounded-lg border-2 border-border bg-surface-2 p-6 md:p-8 text-center space-y-3">
+      <h2 className="text-2xl font-display font-bold">Membership required</h2>
+      <p className="text-muted-foreground max-w-xl mx-auto">
+        You&rsquo;re signed in but not on this term&rsquo;s membership rolls.
+        Earn a membership at any SSE event, then come back to nominate.
+      </p>
+      <Button asChild variant="outline">
+        <Link href="/about/get-involved">How to become a member</Link>
+      </Button>
+    </div>
+  );
+}
+
+function WaitingPanel({ nextSemesterLabel }: { nextSemesterLabel: string }) {
+  return (
+    <div className="rounded-lg border border-border/50 bg-surface-2 p-6 space-y-4">
+      <div className="flex flex-col sm:flex-row gap-3">
+        <Button asChild>
+          <Link href="/about/get-involved">
+            <UserPlus className="mr-2 h-4 w-4" /> Get involved
+          </Link>
+        </Button>
+        <Button asChild variant="outline">
+          <Link href="/about/leadership">Meet current officers</Link>
+        </Button>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        The next nomination window opens with {nextSemesterLabel}. The page
+        below explains who can nominate, who can run, and what each role does.
+      </p>
+    </div>
+  );
+}
+
+function OfficePicker({
+  offices,
+  onPick,
+}: {
+  offices: NominateOffice[];
+  onPick: (officeId: number) => void;
+}) {
+  return (
+    <div className="space-y-3">
+      <h2 className="text-xl font-display font-bold">
+        Pick a position to nominate for
+      </h2>
+      <div className="grid gap-3 md:grid-cols-2">
+        {offices.map((office) => (
+          <OfficeRow key={office.id} office={office} onPick={onPick} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function OfficeRow({
+  office,
+  onPick,
+}: {
+  office: NominateOffice;
+  onPick: (officeId: number) => void;
+}) {
+  return (
+    <div className="rounded-lg border-2 border-border bg-surface-2 p-4 space-y-3 flex flex-col">
+      <div className="flex items-start justify-between gap-2">
+        <h3 className="text-lg font-display font-bold leading-tight">
+          {office.title}
+        </h3>
+        {office.incumbent && (
+          <span className="text-xs text-muted-foreground whitespace-nowrap">
+            Currently {office.incumbent.name}
+          </span>
+        )}
+      </div>
+      <p className="text-sm text-muted-foreground flex-1">
+        {office.description}
+      </p>
+      <Button
+        size="sm"
+        variant="default"
+        onClick={() => onPick(office.id)}
+        className="self-start"
+      >
+        <UserPlus className="mr-2 h-4 w-4" />
+        Nominate
+      </Button>
+    </div>
+  );
+}
+
+function ReceiptPanel({
+  receipt,
+  electionSlug,
+  onAgain,
+}: {
+  receipt: ReceiptState;
+  electionSlug: string;
+  onAgain: () => void;
+}) {
+  return (
+    <div className="rounded-lg border-2 border-success bg-success/10 p-6 space-y-4">
+      <div className="flex items-start gap-3">
+        <CheckCircle2 className="h-6 w-6 text-success shrink-0 mt-0.5" />
+        <div className="space-y-1">
+          <h2 className="text-xl font-display font-bold">
+            Nomination submitted
+          </h2>
+          <p className="text-muted-foreground">
+            We&rsquo;ve recorded your nomination for{" "}
+            <strong className="text-foreground">{receipt.position}</strong>.
+            Your nominee will get an email asking them to accept or decline.
+          </p>
+        </div>
+      </div>
+      <div className="flex flex-col sm:flex-row gap-3">
+        {electionSlug && (
+          <Button asChild variant="default">
+            <Link href={`/elections/${electionSlug}`}>
+              <Vote className="mr-2 h-4 w-4" /> View the ballot
+            </Link>
+          </Button>
+        )}
+        <Button variant="outline" onClick={onAgain}>
+          Nominate someone else
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function ExplainerTiles({
+  isOpen,
+  closesAt,
+  votingOpensAt,
+}: {
+  isOpen: boolean;
+  closesAt: string | null;
+  votingOpensAt: string | null;
+}) {
+  const tiles = isOpen
+    ? [
+        {
+          icon: GraduationCap,
+          title: "Who can nominate?",
+          body: "Any active SSE member — at least one membership earned this term, or last term during the first two weeks of a new one.",
+        },
+        {
+          icon: UserPlus,
+          title: "Who can run?",
+          body: "Any RIT student who'll stay enrolled through the officer year. Eligibility is reviewed once the nominee accepts.",
+        },
+        {
+          icon: Calendar,
+          title: "What happens next?",
+          body: closesAt
+            ? `Nominations close ${closesAt}. Voting opens ${votingOpensAt ?? "soon after"} and runs for one week — ranked-choice.`
+            : "Voting opens after nominations close, and runs for one week using ranked-choice.",
+        },
+      ]
+    : [
+        {
+          icon: GraduationCap,
+          title: "Earn a membership",
+          body: "Show up to any SSE event and swipe in. Memberships are tracked term by term — you'll need at least one to nominate or vote.",
+        },
+        {
+          icon: UserPlus,
+          title: "Read the constitution",
+          body: "Knowing what each role actually does makes you a better nominator (and a better officer if you decide to run).",
+        },
+        {
+          icon: Calendar,
+          title: "Watch this page",
+          body: "When the next ballot opens, this page lights up. No emails, no notifications — just open it in a tab.",
+        },
+      ];
+
+  return (
+    <NeoCard depth={2} className="w-full">
+      <NeoCardContent className="grid gap-4 p-6 md:grid-cols-3">
+        {tiles.map((tile) => (
+          <div key={tile.title} className="space-y-2">
+            <div className="flex items-center gap-2 text-primary">
+              <tile.icon className="h-5 w-5" />
+              <h3 className="text-base font-display font-bold">{tile.title}</h3>
+            </div>
+            <p className="text-sm text-muted-foreground">{tile.body}</p>
+          </div>
+        ))}
+      </NeoCardContent>
+    </NeoCard>
+  );
+}
+
+function RoleManifestCard({
+  roles,
+}: {
+  roles: NominateData["roleManifest"];
+}) {
+  return (
+    <NeoCard depth={2} className="w-full">
+      <NeoCardContent className="p-6 space-y-4">
+        <h2 className="text-xl font-display font-bold">The roles</h2>
+        <ul className="divide-y divide-border/50">
+          {roles.map((role) => (
+            <li
+              key={role.title}
+              className="py-3 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 sm:gap-3"
+            >
+              <div className="space-y-0.5">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span className="font-display font-bold">{role.title}</span>
+                  {!role.onBallot && (
+                    <Badge variant="outline" className="text-[10px] uppercase">
+                      Running-mate pick
+                    </Badge>
+                  )}
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  {role.description}
+                </p>
+              </div>
+              <div className="text-xs text-muted-foreground whitespace-nowrap">
+                {role.incumbent ? (
+                  <>
+                    Currently{" "}
+                    <span className="text-foreground font-medium">
+                      {role.incumbent.name}
+                    </span>
+                  </>
+                ) : (
+                  <span>Vacant</span>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      </NeoCardContent>
+    </NeoCard>
+  );
+}

--- a/next/app/(main)/nominate/page.tsx
+++ b/next/app/(main)/nominate/page.tsx
@@ -1,0 +1,210 @@
+import prisma from "@/lib/prisma";
+import { getAuthLevel } from "@/lib/services/authLevelService";
+import {
+  getActiveElectionWithAutoKickoff,
+  PRIMARY_OFFICER_TITLES,
+  TICKET_DERIVED_OFFICE_TITLES,
+} from "@/lib/elections";
+import { isActiveMemberForElection } from "@/lib/electionEligibility";
+import { resolveUserImage } from "@/lib/s3Utils";
+import {
+  formatAcademicTerm,
+  getNextSemester,
+} from "@/lib/academicTerm";
+import { ElectionStatus } from "@prisma/client";
+import NominateClient from "./NominateClient";
+import type { NominateData } from "./types";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = {
+  title: "Nominate · SSE",
+  description:
+    "Nominate the next Society of Software Engineers officers. Public nomination form for SSE primary officer elections.",
+};
+
+const ROLE_DESCRIPTIONS: Record<string, string> = {
+  President:
+    "Leads the society, presides over meetings, and represents SSE to the school and outside world.",
+  "Vice President":
+    "Runs on the President's ticket. Steps in when the President is away and shares the workload year-round.",
+  Secretary:
+    "Keeps the minutes, tracks attendance and memberships, runs elections paperwork.",
+  Treasurer:
+    "Owns the budget, the SG account, and every dollar SSE spends, raises, or sponsors.",
+  "Mentoring Head":
+    "Recruits and schedules mentors for the SSE lab. Trains them and keeps the lab humming.",
+};
+
+export default async function NominatePage() {
+  const authLevel = await getAuthLevel();
+  const activeElection = await getActiveElectionWithAutoKickoff();
+
+  // Pull active officers (incumbents) for any of the primary-officer
+  // titles, plus all PRIMARY_OFFICER positions that aren't defunct —
+  // used both for the office picker and the role manifest.
+  const positions = await prisma.officerPosition.findMany({
+    where: {
+      category: "PRIMARY_OFFICER",
+      is_defunct: false,
+      title: { in: [...PRIMARY_OFFICER_TITLES] },
+    },
+    select: {
+      id: true,
+      title: true,
+      officers: {
+        where: { is_active: true },
+        select: {
+          user: {
+            select: {
+              id: true,
+              name: true,
+              profileImageKey: true,
+              googleImageURL: true,
+            },
+          },
+        },
+        take: 1,
+      },
+    },
+  });
+
+  const ticketDerived = new Set<string>(TICKET_DERIVED_OFFICE_TITLES);
+
+  const incumbents = Object.fromEntries(
+    positions.map((p) => {
+      const o = p.officers[0];
+      return [
+        p.title,
+        o
+          ? {
+              id: o.user.id,
+              name: o.user.name,
+              image: resolveUserImage(
+                o.user.profileImageKey,
+                o.user.googleImageURL
+              ),
+            }
+          : null,
+      ];
+    })
+  );
+
+  const roleManifest = PRIMARY_OFFICER_TITLES.map((title) => ({
+    title,
+    description: ROLE_DESCRIPTIONS[title] ?? "",
+    incumbent: incumbents[title] ?? null,
+    onBallot: !ticketDerived.has(title),
+  }));
+
+  // If the system has an active election, fetch its offices so we can
+  // populate the position picker. Filter out SE_OFFICE positions and
+  // ticket-derived (Vice President) — Vice President is selected as a
+  // running mate, not nominated directly.
+  let openElection: NominateData["openElection"] = null;
+  let viewerCanNominate = false;
+
+  if (activeElection && activeElection.status === ElectionStatus.NOMINATIONS_OPEN) {
+    const fullElection = await prisma.election.findUnique({
+      where: { id: activeElection.id },
+      select: {
+        id: true,
+        title: true,
+        slug: true,
+        status: true,
+        nominationsOpenAt: true,
+        nominationsCloseAt: true,
+        votingOpenAt: true,
+        votingCloseAt: true,
+        offices: {
+          select: {
+            id: true,
+            officerPosition: {
+              select: {
+                id: true,
+                title: true,
+                category: true,
+                is_defunct: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (fullElection) {
+      const offices = fullElection.offices
+        .filter(
+          (o) =>
+            o.officerPosition.category === "PRIMARY_OFFICER" &&
+            !o.officerPosition.is_defunct &&
+            !ticketDerived.has(o.officerPosition.title)
+        )
+        .map((o) => ({
+          id: o.id,
+          title: o.officerPosition.title,
+          description: ROLE_DESCRIPTIONS[o.officerPosition.title] ?? "",
+          incumbent: incumbents[o.officerPosition.title] ?? null,
+        }));
+
+      openElection = {
+        id: fullElection.id,
+        title: fullElection.title,
+        slug: fullElection.slug,
+        nominationsOpenAt: fullElection.nominationsOpenAt.toISOString(),
+        nominationsCloseAt: fullElection.nominationsCloseAt.toISOString(),
+        votingOpenAt: fullElection.votingOpenAt.toISOString(),
+        votingCloseAt: fullElection.votingCloseAt.toISOString(),
+        offices,
+      };
+
+      if (authLevel.userId) {
+        viewerCanNominate = await isActiveMemberForElection(authLevel.userId);
+      }
+    }
+  }
+
+  // The waiting state surfaces the next academic term so the headline
+  // reads "RESUMES SPRING 2026" rather than a generic "TBD".
+  const nextSemester = getNextSemester();
+  const nextSemesterLabel = formatAcademicTerm(
+    nextSemester.term,
+    nextSemester.year
+  );
+
+  let viewer: NominateData["viewer"] = null;
+  if (authLevel.userId) {
+    const u = await prisma.user.findUnique({
+      where: { id: authLevel.userId },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        major: true,
+        profileImageKey: true,
+        googleImageURL: true,
+      },
+    });
+    if (u) {
+      viewer = {
+        id: u.id,
+        name: u.name,
+        email: u.email,
+        major: u.major,
+        image: resolveUserImage(u.profileImageKey, u.googleImageURL),
+      };
+    }
+  }
+
+  const data: NominateData = {
+    openElection,
+    viewer,
+    viewerCanNominate,
+    isMember: authLevel.isMember,
+    isOfficer: authLevel.isOfficer,
+    nextSemesterLabel,
+    roleManifest,
+  };
+
+  return <NominateClient data={data} />;
+}

--- a/next/app/(main)/nominate/types.ts
+++ b/next/app/(main)/nominate/types.ts
@@ -1,0 +1,47 @@
+/**
+ * Serialized payload that the server `page.tsx` hands to
+ * `NominateClient`. All Date objects are pre-converted to ISO strings
+ * so the data crosses the server-client boundary cleanly.
+ */
+export interface NominateOffice {
+  id: number;
+  title: string;
+  description: string;
+  incumbent: { id: number; name: string; image: string | null } | null;
+}
+
+export interface NominateOpenElection {
+  id: number;
+  title: string;
+  slug: string;
+  nominationsOpenAt: string;
+  nominationsCloseAt: string;
+  votingOpenAt: string;
+  votingCloseAt: string;
+  offices: NominateOffice[];
+}
+
+export interface NominateViewer {
+  id: number;
+  name: string;
+  email: string;
+  major: string | null;
+  image: string | null;
+}
+
+export interface NominateRoleManifestEntry {
+  title: string;
+  description: string;
+  incumbent: { id: number; name: string; image: string | null } | null;
+  onBallot: boolean;
+}
+
+export interface NominateData {
+  openElection: NominateOpenElection | null;
+  viewer: NominateViewer | null;
+  viewerCanNominate: boolean;
+  isMember: boolean;
+  isOfficer: boolean;
+  nextSemesterLabel: string;
+  roleManifest: NominateRoleManifestEntry[];
+}

--- a/next/app/api/elections/auto-kickoff/route.ts
+++ b/next/app/api/elections/auto-kickoff/route.ts
@@ -1,0 +1,51 @@
+import { kickoffElectionForCurrentTerm } from "@/lib/electionAutoKickoff";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Cron-secret guarded endpoint that auto-creates a fresh
+ * NOMINATIONS_OPEN primary officer election when the system has
+ * crossed into a new academic term and nothing is in flight.
+ *
+ * Hit this from Vercel Cron, GitHub Actions, or any external
+ * scheduler. The request must include an `x-cron-secret` header
+ * matching `process.env.CRON_SECRET`. If the env var is unset, the
+ * endpoint refuses to run — auto-kickoff is gated, never anonymous.
+ *
+ * The page route at `/nominate` *also* triggers kickoff lazily on
+ * load, so this endpoint is redundancy for environments without a
+ * scheduler.
+ */
+export async function POST(request: Request) {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) {
+    return new Response(
+      "Auto-kickoff is disabled (CRON_SECRET is not configured).",
+      { status: 503 }
+    );
+  }
+
+  const presented = request.headers.get("x-cron-secret");
+  if (!presented || presented !== secret) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  try {
+    const result = await kickoffElectionForCurrentTerm();
+    return Response.json(result, { status: result.created ? 201 : 200 });
+  } catch (error) {
+    return new Response(
+      error instanceof Error ? error.message : "Auto-kickoff failed",
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * GET is intentionally not implemented — kickoff is a write action
+ * and must come through POST so it isn't accidentally fired by
+ * crawlers or link-previewers.
+ */
+export async function GET() {
+  return new Response("Use POST.", { status: 405 });
+}

--- a/next/components/nav/Navbar.tsx
+++ b/next/components/nav/Navbar.tsx
@@ -240,7 +240,9 @@ const Navbar: React.FC<NavbarProps> = ({
   // SE Office gets the live election as a conditional last entry. The
   // groups array is otherwise stable; we rebuild on prop change so the
   // first-paint server prop and any subsequent client-side election
-  // updates both flow through.
+  // updates both flow through. When nominations are open we also
+  // surface a "Nominate" entry alongside Elections so new members can
+  // jump straight into the public funnel.
   const navGroups = React.useMemo(() => {
     const seOfficeWithElection: NavItem[] = serverActiveElection
       ? [
@@ -250,6 +252,16 @@ const Navbar: React.FC<NavbarProps> = ({
             href: `/elections/${serverActiveElection.slug}`,
             description: "Cast your ballot in the active SSE election.",
           },
+          ...(serverActiveElection.status === "NOMINATIONS_OPEN"
+            ? [
+                {
+                  title: "Nominate",
+                  href: "/nominate",
+                  description:
+                    "Nominate a candidate (or yourself) for the open ballot.",
+                },
+              ]
+            : []),
         ]
       : seOfficeItems;
     return [

--- a/next/lib/electionAutoKickoff.ts
+++ b/next/lib/electionAutoKickoff.ts
@@ -1,0 +1,253 @@
+import prisma from "@/lib/prisma";
+import { ElectionStatus } from "@prisma/client";
+import {
+  getCurrentAcademicTerm,
+  getAcademicTermFromDate,
+  formatAcademicTerm,
+  type TermYear,
+} from "@/lib/academicTerm";
+import {
+  PRIMARY_OFFICER_TITLES,
+  TICKET_DERIVED_OFFICE_TITLES,
+} from "@/lib/elections";
+
+/**
+ * Statuses that count as "an election is currently in flight" — if any
+ * exists, the auto-kickoff is a no-op. DRAFT counts because admins use
+ * draft rows as a staging area; we don't want auto-creation to clobber
+ * an admin's work in progress. CANCELLED and CERTIFIED do NOT count —
+ * they're terminal.
+ */
+const IN_FLIGHT_STATUSES: ElectionStatus[] = [
+  ElectionStatus.DRAFT,
+  ElectionStatus.NOMINATIONS_OPEN,
+  ElectionStatus.NOMINATIONS_CLOSED,
+  ElectionStatus.VOTING_OPEN,
+  ElectionStatus.VOTING_CLOSED,
+  ElectionStatus.TIE_RUNOFF_REQUIRED,
+];
+
+/**
+ * Office titles that should be created as ElectionOffice rows for an
+ * auto-kicked-off election. Pulled from the canonical PRIMARY_OFFICER_TITLES
+ * list, with ticket-derived titles (Vice President — chosen as a running
+ * mate, not on the ballot) excluded.
+ */
+function getAutoKickoffOfficeTitles(): readonly string[] {
+  const ticketDerived = new Set<string>(TICKET_DERIVED_OFFICE_TITLES);
+  return PRIMARY_OFFICER_TITLES.filter((t) => !ticketDerived.has(t));
+}
+
+function sameTerm(a: TermYear, b: TermYear): boolean {
+  return a.term === b.term && a.year === b.year;
+}
+
+/**
+ * Decide whether the system should auto-create a new primary officer
+ * election. Returns true when:
+ *   - No election is currently in flight (DRAFT / NOMINATIONS_* / VOTING_* /
+ *     TIE_RUNOFF_REQUIRED), AND
+ *   - The most recent CERTIFIED election was for a different academic
+ *     term than the current one (i.e. a new semester has begun since
+ *     the last cycle was certified), OR there has never been a
+ *     certified election at all (bootstrap).
+ *
+ * The term of a past election is derived from `nominationsCloseAt`
+ * (the date the cycle was sealed), passed through
+ * `getAcademicTermFromDate` so it ties to the canonical academic
+ * calendar config in `lib/academicTerm.ts`.
+ */
+export async function shouldKickoffNewElection(
+  atDate: Date = new Date()
+): Promise<boolean> {
+  const inFlight = await prisma.election.count({
+    where: { status: { in: IN_FLIGHT_STATUSES } },
+  });
+  if (inFlight > 0) return false;
+
+  const lastCertified = await prisma.election.findFirst({
+    where: { status: ElectionStatus.CERTIFIED },
+    orderBy: { nominationsCloseAt: "desc" },
+    select: { nominationsCloseAt: true, certifiedAt: true },
+  });
+
+  if (!lastCertified) {
+    // Bootstrap: no certified history. Allow auto-creation so a fresh
+    // install isn't stuck waiting for a manual admin click. Production
+    // deployments will already have certified history before reaching
+    // this branch.
+    return true;
+  }
+
+  const reference = lastCertified.certifiedAt ?? lastCertified.nominationsCloseAt;
+  const certifiedTerm = {
+    term: getAcademicTermFromDate(reference),
+    year: reference.getFullYear(),
+  };
+  const currentTerm = getCurrentAcademicTerm(atDate);
+  return !sameTerm(certifiedTerm, currentTerm);
+}
+
+/**
+ * Pick a User row to attribute auto-kickoff creation to. The
+ * `Election.createdById` foreign key is non-nullable, so we need a
+ * concrete user. Preference order:
+ *   1. Currently active President — the conventional kickoff role.
+ *   2. Any active SE Office holder — they administer elections.
+ *   3. Most recent past `Election.certifiedById` — at least someone
+ *      historically associated with this responsibility.
+ *
+ * Returns null if none of those exist (very-fresh-install case), in
+ * which case the caller should fall back to manual creation.
+ */
+async function pickKickoffActor(): Promise<number | null> {
+  const president = await prisma.officer.findFirst({
+    where: {
+      is_active: true,
+      position: { title: "President" },
+    },
+    select: { user_id: true },
+  });
+  if (president) return president.user_id;
+
+  const seOfficeHolder = await prisma.officer.findFirst({
+    where: {
+      is_active: true,
+      position: { category: "SE_OFFICE" },
+    },
+    select: { user_id: true },
+  });
+  if (seOfficeHolder) return seOfficeHolder.user_id;
+
+  const lastCertifier = await prisma.election.findFirst({
+    where: { certifiedById: { not: null } },
+    orderBy: { certifiedAt: "desc" },
+    select: { certifiedById: true },
+  });
+  return lastCertifier?.certifiedById ?? null;
+}
+
+function buildSlug(term: TermYear): string {
+  return `${term.term.toLowerCase()}-${term.year}-primary`;
+}
+
+async function uniqueSlug(base: string): Promise<string> {
+  let candidate = base;
+  let suffix = 1;
+  while (
+    await prisma.election.findUnique({
+      where: { slug: candidate },
+      select: { id: true },
+    })
+  ) {
+    candidate = `${base}-${suffix}`;
+    suffix += 1;
+  }
+  return candidate;
+}
+
+export interface KickoffResult {
+  created: boolean;
+  electionId?: number;
+  electionSlug?: string;
+  reason?: string;
+}
+
+/**
+ * Idempotently create a new NOMINATIONS_OPEN primary officer election
+ * for the current academic term, plus the standard set of
+ * ElectionOffice rows. No-op when an in-flight election already exists
+ * or when the most recent CERTIFIED election is for the current term.
+ *
+ * Default windows (overridable):
+ *   - Nominations: now → +14 days
+ *   - Voting:      +16 days → +23 days
+ * (>= 48 hour gap between nominations close and voting open per
+ *  `validateElectionWindow` in `lib/elections.ts`.)
+ */
+export async function kickoffElectionForCurrentTerm(
+  options: {
+    atDate?: Date;
+    nominationsDays?: number;
+    breakDays?: number;
+    votingDays?: number;
+  } = {}
+): Promise<KickoffResult> {
+  const atDate = options.atDate ?? new Date();
+  const nominationsDays = options.nominationsDays ?? 14;
+  const breakDays = options.breakDays ?? 2;
+  const votingDays = options.votingDays ?? 7;
+
+  if (!(await shouldKickoffNewElection(atDate))) {
+    return { created: false, reason: "An election is already in progress for this term." };
+  }
+
+  const actorId = await pickKickoffActor();
+  if (actorId == null) {
+    return {
+      created: false,
+      reason: "No eligible kickoff actor found (no active President, SE Office holder, or past certifier).",
+    };
+  }
+
+  const term = getCurrentAcademicTerm(atDate);
+  const title = `${formatAcademicTerm(term.term, term.year)} Primary Officer Election`;
+  const slug = await uniqueSlug(buildSlug(term));
+
+  const day = 24 * 60 * 60 * 1000;
+  const nominationsOpenAt = new Date(atDate);
+  const nominationsCloseAt = new Date(atDate.getTime() + nominationsDays * day);
+  const votingOpenAt = new Date(
+    nominationsCloseAt.getTime() + breakDays * day
+  );
+  const votingCloseAt = new Date(votingOpenAt.getTime() + votingDays * day);
+
+  const officeTitles = getAutoKickoffOfficeTitles();
+  const positions = await prisma.officerPosition.findMany({
+    where: {
+      title: { in: [...officeTitles] },
+      category: "PRIMARY_OFFICER",
+      is_defunct: false,
+    },
+    select: { id: true, title: true },
+  });
+
+  if (positions.length === 0) {
+    return {
+      created: false,
+      reason: "No matching primary officer positions configured.",
+    };
+  }
+
+  const election = await prisma.$transaction(async (tx) => {
+    const created = await tx.election.create({
+      data: {
+        title,
+        slug,
+        description: `Auto-created at the start of ${formatAcademicTerm(
+          term.term,
+          term.year
+        )}.`,
+        status: ElectionStatus.NOMINATIONS_OPEN,
+        nominationsOpenAt,
+        nominationsCloseAt,
+        votingOpenAt,
+        votingCloseAt,
+        createdById: actorId,
+      },
+      select: { id: true, slug: true },
+    });
+
+    await tx.electionOffice.createMany({
+      data: positions.map((p) => ({
+        electionId: created.id,
+        officerPositionId: p.id,
+      })),
+      skipDuplicates: true,
+    });
+
+    return created;
+  });
+
+  return { created: true, electionId: election.id, electionSlug: election.slug };
+}

--- a/next/lib/elections.ts
+++ b/next/lib/elections.ts
@@ -57,6 +57,39 @@ export const getActiveElection = cache(
 );
 
 /**
+ * Same shape as `getActiveElection` but with auto-kickoff: when no
+ * live election is found AND the system has crossed into a new
+ * academic term since the last CERTIFIED cycle, create one before
+ * returning. Intentionally NOT wrapped in `cache()` so it runs at most
+ * once per request (the page route that calls it is the only consumer).
+ *
+ * The navbar and banner deliberately keep using the plain cached
+ * `getActiveElection` so we don't trigger DB writes on every page load.
+ */
+export async function getActiveElectionWithAutoKickoff(): Promise<ActiveElectionSummary | null> {
+  const existing = await prisma.election.findFirst({
+    where: { status: { in: LIVE_ELECTION_STATUSES } },
+    select: { id: true, title: true, slug: true, status: true },
+    orderBy: { createdAt: "desc" },
+  });
+  if (existing) return existing;
+
+  // Defer the import so this module's startup cost stays the same
+  // for callers that don't need kickoff.
+  const { kickoffElectionForCurrentTerm } = await import(
+    "@/lib/electionAutoKickoff"
+  );
+  const result = await kickoffElectionForCurrentTerm();
+  if (!result.created || !result.electionId) {
+    return null;
+  }
+  return prisma.election.findUnique({
+    where: { id: result.electionId },
+    select: { id: true, title: true, slug: true, status: true },
+  });
+}
+
+/**
  * Post-Amendment 12/13: Vice President is no longer separately elected —
  * it is chosen as a running mate by the President nominee. Mentoring Head
  * is now a Primary Officer elected by the membership.

--- a/next/lib/middlewares/authentication.ts
+++ b/next/lib/middlewares/authentication.ts
@@ -331,6 +331,27 @@ const invitationsVerifier: AuthVerifier = async (request: NextRequest) => {
 };
 
 /**
+ * Auth verifier for election routes:
+ *  - GET is public (election results / nomination listing).
+ *  - POST /api/elections/auto-kickoff is the cron-secret guarded
+ *    endpoint that creates a fresh election at semester boundaries.
+ *    The route handler does its own `x-cron-secret` check, so the
+ *    middleware needs to *let it through* — sign-in isn't possible
+ *    in a scheduler context.
+ *  - All other mutations require a signed-in user (the route
+ *    handlers run finer-grained checks like active membership).
+ */
+const electionsVerifier: AuthVerifier = async (request: NextRequest) => {
+  if (request.method === "GET") {
+    return { isAllowed: true, authType: "None" };
+  }
+  if (request.nextUrl.pathname === "/api/elections/auto-kickoff") {
+    return { isAllowed: true, authType: "None" };
+  }
+  return signedInVerifier(request);
+};
+
+/**
  * Map from API route name to authorization verifier. The verifier should be run against any request that
  * goes through that route.
  * Keys are the second element in the path segment; for example, the path "/api/golinks/officer" would
@@ -351,7 +372,7 @@ const ROUTES: { [key: string]: AuthVerifier } = {
   courseTaken: nonGetMentorVerifier,
   departments: nonGetOfficerVerifier,
   email: officerVerifier,
-  elections: nonGetVerifier(signedInVerifier),
+  elections: electionsVerifier,
   event: eventVerifier,
   go: allowAllVerifier,
   golinks: goLinkVerifier,


### PR DESCRIPTION
Closes #521

## Summary
- New public `/nominate` page (server + client) with sign-in gate, active-membership check, position picker, inline user search, and a ballot-stub success receipt. Reuses the existing `POST /api/elections/[id]/nominations` submit pipeline — no duplicate API logic.
- Letterpress-civic-poster aesthetic in a page-scoped CSS module: `Big Shoulders` + `Fraunces` + `JetBrains Mono` via `next/font/google`, cream + ink + cobalt + acid-yellow palette, paper grain and halftone gutter overlays, `motion/react` reveals with full `prefers-reduced-motion` fallback. Page-scoped CSS variables so nothing leaks site-wide.
- `electionAutoKickoff` lib + cron-secret endpoint at `POST /api/elections/auto-kickoff` that creates a fresh `NOMINATIONS_OPEN` election when the system has crossed into a new academic term and nothing is in flight. Also lazy-triggered on `/nominate` page load via a new `getActiveElectionWithAutoKickoff` so the form materializes without a configured scheduler.
- Navbar gets a `NOMINATE` link (desktop + mobile) with an acid-yellow pulse dot, conditional on an active `NOMINATIONS_OPEN` election.
- Auth middleware grows an `electionsVerifier` that lets the cron endpoint through so its own `x-cron-secret` check runs (existing 31 middleware tests still pass).

## Testing
- `npm run typecheck` — clean
- `npm run lint` — clean (0 errors / 0 warnings)
- `npx vitest run electionAutoKickoff electionEligibility elections.lib authMiddleware` — 51/51 pass (7 new for `shouldKickoffNewElection` + `kickoffElectionForCurrentTerm`)
- `next dev -p 3005` boots in ~440ms; cron endpoint guard verified end-to-end (no header → 401, wrong header → 401, correct `x-cron-secret` → reaches the kickoff handler).

## Notes for the reviewer
- `getActiveElection()` is still the cached helper used by the navbar / banners on every request; only the new `getActiveElectionWithAutoKickoff()` triggers DB writes, and only `/nominate` calls it.
- `CRON_SECRET` env var is required for the auto-kickoff endpoint to do anything; without it the route returns 503 by design.
- `Vice President` is intentionally excluded from the office picker because it's chosen as the President's running mate (Amendment 12) — confirmed via `TICKET_DERIVED_OFFICE_TITLES` in `lib/elections.ts`.