### PR TITLE
Align Vitest coverage dependency

### DIFF
--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -83,7 +83,7 @@
         "@types/jsonwebtoken": "^9.0.7",
         "@types/node": "^25.6.0",
         "@types/nodemailer": "^7.0.5",
-        "@vitest/coverage-v8": "^4.0.18",
+        "@vitest/coverage-v8": "^4.1.5",
         "cross-env": "^10.0.0",
         "eslint-plugin-react-hooks": "^7.0.1",
         "husky": "^9.1.7",

--- a/next/package.json
+++ b/next/package.json
@@ -103,7 +103,7 @@
     "@types/jsonwebtoken": "^9.0.7",
     "@types/node": "^25.6.0",
     "@types/nodemailer": "^7.0.5",
-    "@vitest/coverage-v8": "^4.0.18",
+    "@vitest/coverage-v8": "^4.1.5",
     "cross-env": "^10.0.0",
     "eslint-plugin-react-hooks": "^7.0.1",
     "husky": "^9.1.7",


### PR DESCRIPTION
## Summary
- Updates `@vitest/coverage-v8` to `^4.1.5` so it matches the merged `vitest` `^4.1.5` update from #462.
- Replaces stale Dependabot PR #463, whose lockfile now conflicts after #462 landed.

## Testing
- `fnm exec --using v20.20.1 npm --prefix next run knip`
- `fnm exec --using v20.20.1 npm --prefix next run lint`
- `fnm exec --using v20.20.1 npm --prefix next run test`
- `fnm exec --using v20.20.1 npm --prefix next run typecheck`
- `fnm exec --using v20.20.1 npm --prefix next run build`

## Notes
Build completed successfully. It logged local dashboard summary Prisma warnings because the temp worktree did not have `DATABASE_URL`, but the build finished.

Supersedes #463.