### PR TITLE
Fix committee head enum migration ordering

### DIFF
--- a/next/prisma/migrations/20260501005900_add_committee_head_position_category/migration.sql
+++ b/next/prisma/migrations/20260501005900_add_committee_head_position_category/migration.sql
@@ -1,0 +1,4 @@
+-- Add and commit this enum value before the committee-head nomination
+-- migration uses it in UPDATE statements. PostgreSQL rejects use of a
+-- newly-added enum value in the same transaction that added it.
+ALTER TYPE "PositionCategory" ADD VALUE IF NOT EXISTS 'COMMITTEE_HEAD';


### PR DESCRIPTION
## Summary
- add a pre-migration that commits the COMMITTEE_HEAD PositionCategory enum value before the committee-head nomination migration uses it
- avoids PostgreSQL's unsafe enum value error during fresh/dev/prod migrate deploy runs

## Verification
- manually repaired ssedev by applying the enum first, applying the rest of the migration, and marking the failed migration applied
- reran Docker CI for development successfully after repair
- confirmed website-dev is up and serving commit 60d568f assets