### PR TITLE
fix: readded seeding of mentors because it was removed for some reason

### DIFF
--- a/next/prisma/seed.ts
+++ b/next/prisma/seed.ts
@@ -1795,6 +1795,8 @@ async function main() {
     await seedOfficerPosition(); // Officer positions (can exist without officers)
     await seedOfficer(); // Test officer assignment for development
     await seedMentor();
+    await seedMentorSchedule(); // Sample mentor schedule (needed by seedScheduleBlock)
+    await seedScheduleBlock(); // Sample weekly coverage blocks for the public schedule page
     await seedAlumni();
     await seedSkill();
     await seedMentorSkill();


### PR DESCRIPTION
## Summary
readded mentor schedule seeding to prisma methods because it was removed in the past for some reason
